### PR TITLE
FEAT: Instanced rendering for trees via merged mesh + texture atlas […

### DIFF
--- a/assets/shaders/tree_atlas.wgsl
+++ b/assets/shaders/tree_atlas.wgsl
@@ -1,0 +1,16 @@
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+@group(2) @binding(0) var base_texture: texture_2d<f32>;
+@group(2) @binding(1) var base_sampler: sampler;
+
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    let color = textureSample(base_texture, base_sampler, in.uv);
+
+    // Alpha test — discard instead of blend
+    if color.a < 0.5 {
+        discard;
+    }
+
+    return color;
+}

--- a/crates/client/src/rendering/terrain/components/mod.rs
+++ b/crates/client/src/rendering/terrain/components/mod.rs
@@ -1,7 +1,9 @@
 mod biome;
 mod building;
 mod terrain;
+mod tree_global_mesh;
 
 pub use biome::Biome;
 pub use building::Building;
 pub use terrain::Terrain;
+pub use tree_global_mesh::TreeGlobalMesh;

--- a/crates/client/src/rendering/terrain/components/tree_global_mesh.rs
+++ b/crates/client/src/rendering/terrain/components/tree_global_mesh.rs
@@ -1,0 +1,4 @@
+use bevy::prelude::*;
+
+#[derive(Component)]
+pub struct TreeGlobalMesh;

--- a/crates/client/src/rendering/terrain/materials/mod.rs
+++ b/crates/client/src/rendering/terrain/materials/mod.rs
@@ -1,3 +1,5 @@
 mod terrain_material;
+mod tree_material;
 
 pub use terrain_material::*;
+pub use tree_material::*;

--- a/crates/client/src/rendering/terrain/materials/tree_material.rs
+++ b/crates/client/src/rendering/terrain/materials/tree_material.rs
@@ -1,0 +1,21 @@
+use bevy::prelude::*;
+use bevy::render::render_resource::AsBindGroup;
+use bevy::shader::ShaderRef;
+use bevy::sprite_render::{AlphaMode2d, Material2d};
+
+#[derive(Asset, TypePath, AsBindGroup, Clone)]
+pub struct TreeMaterial {
+    #[texture(0)]
+    #[sampler(1)]
+    pub texture: Handle<Image>,
+}
+
+impl Material2d for TreeMaterial {
+    fn fragment_shader() -> ShaderRef {
+        "shaders/tree_atlas.wgsl".into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Opaque // GPU traite comme opaque — le shader fait le discard
+    }
+}

--- a/crates/client/src/rendering/terrain/plugin.rs
+++ b/crates/client/src/rendering/terrain/plugin.rs
@@ -4,25 +4,28 @@
 
 use bevy::{prelude::*, sprite_render::Material2dPlugin};
 
-use crate::rendering::terrain::materials::TerrainMaterial;
+use crate::rendering::terrain::materials::{TerrainMaterial, TreeMaterial};
 use crate::states::AppState;
 
-pub use super::systems;
 use super::debug;
+pub use super::systems;
 
 pub struct TerrainPlugin;
 
 impl Plugin for TerrainPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(Material2dPlugin::<TerrainMaterial>::default())
+            .add_plugins(Material2dPlugin::<TreeMaterial>::default())
             .init_resource::<debug::ChunkDebugEnabled>()
             .add_systems(
                 Update,
                 (
                     systems::initialize_terrain,
+                    systems::build_tree_atlas,
                     systems::request_terrain_global_data,
                     systems::create_terrain_global_textures,
                     systems::spawn_terrain,
+                    systems::rebuild_tree_mesh,
                     systems::spawn_building,
                     debug::toggle_chunk_debug,
                     debug::draw_chunk_gizmos,

--- a/crates/client/src/rendering/terrain/systems.rs
+++ b/crates/client/src/rendering/terrain/systems.rs
@@ -1,5 +1,6 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
+use bevy::mesh::Indices;
 use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
 use bevy::{asset::RenderAssetUsages, mesh::PrimitiveTopology, prelude::*};
 use hexx::Hex;
@@ -16,8 +17,9 @@ use shared::{
 use super::components::{Biome, Building, Terrain};
 use super::materials::TerrainMaterial;
 use crate::networking::client::NetworkClient;
+use crate::rendering::terrain::components::TreeGlobalMesh;
 use crate::rendering::terrain::materials::{
-    BiomeParams, ChunkInfo, HeightmapParams, LakeParams, RoadParams, SdfParams
+    BiomeParams, ChunkInfo, HeightmapParams, LakeParams, RoadParams, SdfParams, TreeMaterial,
 };
 use crate::state::resources::{ConnectionStatus, WorldCache};
 
@@ -255,29 +257,28 @@ pub fn spawn_terrain(
                 (dummy, HeightmapParams::default())
             };
 
-        let (lake_sdf_texture, lake_params) =
-            if let Some(lh) = world_cache.get_lake_sdf_handle() {
-                (
-                    lh.clone(),
-                    LakeParams {
-                        has_lake: 1.0,
-                        ..default()
-                    },
-                )
-            } else {
-                let dummy = images.add(Image::new(
-                    Extent3d {
-                        width: 1,
-                        height: 1,
-                        depth_or_array_layers: 1,
-                    },
-                    TextureDimension::D2,
-                    vec![255u8], // all land = no lake
-                    TextureFormat::R8Unorm,
-                    default(),
-                ));
-                (dummy, LakeParams::default())
-            };
+        let (lake_sdf_texture, lake_params) = if let Some(lh) = world_cache.get_lake_sdf_handle() {
+            (
+                lh.clone(),
+                LakeParams {
+                    has_lake: 1.0,
+                    ..default()
+                },
+            )
+        } else {
+            let dummy = images.add(Image::new(
+                Extent3d {
+                    width: 1,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+                TextureDimension::D2,
+                vec![255u8], // all land = no lake
+                TextureFormat::R8Unorm,
+                default(),
+            ));
+            (dummy, LakeParams::default())
+        };
 
         let material_handle = if let Some(sdf) = terrain.sdf_data.first() {
             let sdf_texture = create_sdf_texture_from_data(sdf, &mut images);
@@ -607,68 +608,9 @@ pub fn spawn_building(
         // );
 
         match (&building_base.category, &building.specific_data) {
-            (BuildingCategoryEnum::Natural, BuildingSpecific::Tree(tree_data)) => {
-                let tree_type = TreeTypeEnum::Cedar; // TODO: create assets for oak and larch
-                // let tree_type = tree_data.tree_type;
-                let age = TreeAge::get_tree_age(tree_data.age as u32);
-                let variation = tree_data.variant;
-                let density = match tree_data.density {
-                    (..0.45) => 1,
-                    (0.45..0.55) => 2,
-                    (0.55..0.65) => 3,
-                    (0.65..0.75) => 4,
-                    (0.75..0.85) => 5,
-                    (0.85..) => 6,
-                    _ => 6,
-                };
-
-                let variant = &format!(
-                    "{}_{}_{:02}{:02}",
-                    tree_type.to_name_lowercase(),
-                    age.to_name(),
-                    variation,
-                    density
-                );
-                let image_handle = tree_atlas
-                    .handles
-                    .get(variant)
-                    .expect(format!("Tree variation not found {}", variant).as_str());
-
-                let image_size = images.get(&*image_handle).map(|img| {
-                    let size = img.texture_descriptor.size;
-                    Vec2::new(size.width as f32, size.height as f32)
-                });
-
-                let scale_var = rng.random_range(0.9..=1.1);
-                let flip_x = rng.random_bool(0.5);
-
-                let offset_x: f32 = rng.random_range(-8.0..=8.0);
-                let offset_y: f32 = rng.random_range(-8.0..=8.0);
-
-                world_position.x += offset_x;
-                world_position.y += offset_y + 8.0; // shift slightly up
-
-                let custom_size = image_size.map(|size| {
-                    let width = size.x.min(256.0f32) * scale_var * 64. / 256.; // TODO: assets shall be already downsized
-                    let height = width * (size.y / size.x) * scale_var; // Aspect ratio conservé
-                    Vec2::new(width, height)
-                });
-
-                commands.spawn((
-                    Name::new(format!("{}_{}", &variant, building_id)),
-                    Sprite {
-                        image: image_handle.clone(),
-                        custom_size,
-                        flip_x,
-                        ..default()
-                    },
-                    Transform::from_translation(world_position.extend(-world_position.y * 0.0001)),
-                    GlobalTransform::default(),
-                    Visibility::default(),
-                    Building {
-                        id: building_id as i64,
-                    },
-                ));
+            (BuildingCategoryEnum::Natural, BuildingSpecific::Tree(_tree_data)) => {
+                // Trees are rendered via instanced mesh merging in spawn_tree_meshes
+                continue;
             }
             (
                 BuildingCategoryEnum::ManufacturingWorkshops,
@@ -1047,11 +989,269 @@ fn is_segment_on_chunk_edge(a: Vec2, b: Vec2, threshold: f32, max_x: f32, max_y:
     on_left || on_right || on_bottom || on_top
 }
 
-// Wave animation disabled for terrain_signed_sdf.wgsl shader
-// pub fn update_terrain_wave_time(time: Res<Time>, mut materials: ResMut<Assets<TerrainMaterial>>) {
-//     let elapsed = time.elapsed_secs();
-//
-//     for (_, material) in materials.iter_mut() {
-//         material.wave_params.time = elapsed;
-//     }
-// }
+/// Pack individual tree sprites into a single texture atlas
+pub fn build_tree_atlas(
+    mut tree_atlas: ResMut<TreeAtlas>,
+    mut images: ResMut<Assets<Image>>,
+    mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
+    mut built: Local<bool>,
+) {
+    if *built || tree_atlas.atlas_image.is_some() {
+        return;
+    }
+
+    let variant_names: Vec<String> = tree_atlas
+        .sprites
+        .values()
+        .flat_map(|v| v.iter().cloned())
+        .collect();
+
+    if variant_names.is_empty() {
+        return;
+    }
+
+    let all_loaded = variant_names.iter().all(|name| {
+        tree_atlas
+            .handles
+            .get(name.as_str())
+            .and_then(|h| images.get(h))
+            .is_some()
+    });
+
+    if !all_loaded {
+        return;
+    }
+
+    let sprite_size = 256u32;
+    let cols = 5u32;
+    let rows = (variant_names.len() as u32 + cols - 1) / cols;
+    let atlas_width = cols * sprite_size;
+    let atlas_height = rows * sprite_size;
+
+    info!(
+        "Building tree atlas: {}x{} ({} variants)",
+        atlas_width,
+        atlas_height,
+        variant_names.len()
+    );
+
+    let mut atlas_data = vec![0u8; (atlas_width * atlas_height * 4) as usize];
+
+    for (idx, name) in variant_names.iter().enumerate() {
+        let handle = tree_atlas.handles.get(name.as_str()).unwrap();
+        let image = images.get(handle).unwrap();
+        let src_data = image.data.as_ref().unwrap();
+        let src_w = image.texture_descriptor.size.width;
+        let src_h = image.texture_descriptor.size.height;
+
+        let col = (idx as u32) % cols;
+        let row = (idx as u32) / cols;
+        let dst_x = col * sprite_size;
+        let dst_y = row * sprite_size;
+
+        for y in 0..src_h.min(sprite_size) {
+            for x in 0..src_w.min(sprite_size) {
+                let src_idx = ((y * src_w + x) * 4) as usize;
+                let dst_idx = (((dst_y + y) * atlas_width + dst_x + x) * 4) as usize;
+                if src_idx + 3 < src_data.len() && dst_idx + 3 < atlas_data.len() {
+                    atlas_data[dst_idx] = src_data[src_idx];
+                    atlas_data[dst_idx + 1] = src_data[src_idx + 1];
+                    atlas_data[dst_idx + 2] = src_data[src_idx + 2];
+                    atlas_data[dst_idx + 3] = src_data[src_idx + 3];
+                }
+            }
+        }
+
+        tree_atlas.variants.insert(name.clone(), idx);
+    }
+
+    let atlas_image = Image::new(
+        Extent3d {
+            width: atlas_width,
+            height: atlas_height,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        atlas_data,
+        TextureFormat::Rgba8UnormSrgb,
+        RenderAssetUsages::RENDER_WORLD,
+    );
+
+    let layout =
+        TextureAtlasLayout::from_grid(UVec2::new(sprite_size, sprite_size), cols, rows, None, None);
+
+    tree_atlas.sprite_size = sprite_size;
+    tree_atlas.atlas_cols = cols;
+    tree_atlas.atlas_rows = rows;
+    tree_atlas.atlas_image = Some(images.add(atlas_image));
+    tree_atlas.atlas_layout = Some(texture_atlas_layouts.add(layout));
+
+    info!(
+        "✓ Tree atlas built: {}x{} ({} variants)",
+        atlas_width,
+        atlas_height,
+        variant_names.len()
+    );
+    *built = true;
+}
+
+/// Single merged mesh for ALL visible trees. Rebuilt when building cache changes.
+pub fn rebuild_tree_mesh(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut tree_materials: ResMut<Assets<TreeMaterial>>,
+    mut world_cache: Option<ResMut<WorldCache>>,
+    tree_atlas: Res<TreeAtlas>,
+    grid_config: Res<GridConfig>,
+    existing: Query<Entity, With<TreeGlobalMesh>>,
+    mut shared_material: Local<Option<MeshMaterial2d<TreeMaterial>>>,
+) {
+    let Some(ref mut world_cache) = world_cache else { return; };
+
+    if !world_cache.is_buildings_dirty() && existing.iter().count() > 0 {
+        return;
+    }
+
+    let Some(atlas_image) = &tree_atlas.atlas_image else { return; };
+
+    world_cache.clear_buildings_dirty();
+
+    for entity in existing.iter() {
+        commands.entity(entity).despawn();
+    }
+
+    let material = shared_material.get_or_insert_with(|| {
+        MeshMaterial2d(tree_materials.add(TreeMaterial {
+            texture: atlas_image.clone(),
+        }))
+    }).clone();
+
+    // Collect ALL tree quads
+    let mut quads: Vec<TreeQuad> = Vec::new();
+
+    for building in world_cache.loaded_buildings() {
+        let shared::BuildingSpecific::Tree(tree_data) = &building.specific_data else { continue };
+
+        let tree_type = shared::TreeTypeEnum::Cedar;
+        let age = shared::TreeAge::get_tree_age(tree_data.age as u32);
+        let variation = tree_data.variant;
+        let building_id = building.base_data.id;
+
+        let cell_pos = grid_config.layout.hex_to_world_pos(
+            hexx::Hex::new(building.base_data.cell.q, building.base_data.cell.r),
+        );
+
+        let tree_count = match tree_data.density {
+            d if d < 0.35 => 1,
+            d if d < 0.50 => 2,
+            d if d < 0.60 => 3,
+            d if d < 0.70 => 4,
+            d if d < 0.80 => 5,
+            d if d < 0.90 => 6,
+            d if d < 0.95 => 7,
+            _ => 8,
+        };
+
+        for tree_i in 0..tree_count {
+            let sub_seed = building_id.wrapping_mul(31).wrapping_add(tree_i as u64);
+            let mut sub_rng = rand::rngs::StdRng::seed_from_u64(sub_seed);
+
+            let offset_x: f32 = sub_rng.random_range(-18.0..=18.0);
+            let offset_y: f32 = sub_rng.random_range(-18.0..=18.0);
+            let scale_var: f32 = sub_rng.random_range(0.85..=1.15);
+            let flip_x: bool = sub_rng.random_bool(0.5);
+
+            let (sub_age, sub_var) = if tree_i > 0 {
+                let alt_var = sub_rng.random_range(1..=3i32);
+                let alt_age = shared::TreeAge::get_tree_age(
+                    (tree_data.age as i32 + sub_rng.random_range(-30..=30)).max(0) as u32,
+                );
+                (alt_age, alt_var)
+            } else {
+                (age, variation)
+            };
+
+            let variant_key = format!(
+                "{}_{}_{:02}01",
+                tree_type.to_name_lowercase(),
+                sub_age.to_name(),
+                sub_var
+            );
+
+            let Some(uvs) = tree_atlas.get_atlas_uvs(&variant_key) else { continue };
+
+            let pos = Vec2::new(
+                cell_pos.x + offset_x,
+                cell_pos.y + offset_y + 8.0,
+            );
+            let display_size = 48.0 * scale_var;
+
+            quads.push(TreeQuad { pos, size: display_size, uvs, flip_x });
+        }
+    }
+
+    if quads.is_empty() {
+        return;
+    }
+
+    // Global sort back-to-front: higher Y drawn first
+    quads.sort_by(|a, b| b.pos.y.partial_cmp(&a.pos.y).unwrap());
+
+    // Build single mesh
+    let mut positions: Vec<[f32; 3]> = Vec::with_capacity(quads.len() * 4);
+    let mut uvs_out: Vec<[f32; 2]> = Vec::with_capacity(quads.len() * 4);
+    let mut indices: Vec<u32> = Vec::with_capacity(quads.len() * 6);
+
+    for (qi, quad) in quads.iter().enumerate() {
+        let half = quad.size / 2.0;
+        let base_idx = (qi * 4) as u32;
+
+        positions.push([quad.pos.x - half, quad.pos.y - half, 0.0]);
+        positions.push([quad.pos.x + half, quad.pos.y - half, 0.0]);
+        positions.push([quad.pos.x + half, quad.pos.y + half, 0.0]);
+        positions.push([quad.pos.x - half, quad.pos.y + half, 0.0]);
+
+        let [u_min, v_min, u_max, v_max] = quad.uvs;
+        let (ul, ur) = if quad.flip_x { (u_max, u_min) } else { (u_min, u_max) };
+
+        uvs_out.push([ul, v_max]);
+        uvs_out.push([ur, v_max]);
+        uvs_out.push([ur, v_min]);
+        uvs_out.push([ul, v_min]);
+
+        indices.push(base_idx);
+        indices.push(base_idx + 1);
+        indices.push(base_idx + 2);
+        indices.push(base_idx);
+        indices.push(base_idx + 2);
+        indices.push(base_idx + 3);
+    }
+
+    let normals = vec![[0.0, 0.0, 1.0]; positions.len()];
+
+    let mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::RENDER_WORLD)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs_out)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
+        .with_inserted_indices(Indices::U32(indices));
+
+    info!(
+        "✓ Tree mesh rebuilt: {} quads {} vertices",
+        quads.len(), quads.len() * 4
+    );
+
+    commands.spawn((
+        Name::new("TreeGlobalMesh"),
+        Mesh2d(meshes.add(mesh)),
+        material,
+        Transform::from_translation(Vec3::new(0.0, 0.0, -0.5)),
+        TreeGlobalMesh,
+    ));
+}
+
+struct TreeQuad {
+    pos: Vec2,
+    size: f32,
+    uvs: [f32; 4], // u_min, v_min, u_max, v_max
+    flip_x: bool,
+}

--- a/crates/client/src/state/resources/tree_atlas.rs
+++ b/crates/client/src/state/resources/tree_atlas.rs
@@ -12,19 +12,20 @@ pub fn setup_tree_atlas(mut commands: Commands, asset_server: Res<AssetServer>) 
             continue;
         }
 
-        let mut variations = HashMap::new();
         let sprite_variations = atlas
             .get_variations(tree_type)
-            .expect(format!("No variation found for tree type {:?}", tree_type).as_str());
+            .expect(format!("No variation found for tree type {:?}", tree_type).as_str())
+            .to_vec();
 
         for sprite_variation in sprite_variations {
             let path = format!("sprites/trees/{}.png", sprite_variation);
-            variations.insert(sprite_variation.clone(), asset_server.load(path));
+            atlas
+                .handles
+                .insert(sprite_variation.clone(), asset_server.load(path));
         }
-
-        atlas.handles.extend(variations);
     }
 
+    let count = atlas.handles.len();
     commands.insert_resource(atlas);
-    info!("✓ Tree atlas loaded");
+    info!("✓ Tree atlas loaded ({} variants)", count);
 }

--- a/crates/client/src/state/resources/world_cache.rs
+++ b/crates/client/src/state/resources/world_cache.rs
@@ -115,6 +115,7 @@ impl CellCache {
 #[derive(Default, Clone)]
 pub struct BuildingCache {
     loaded: HashMap<GridCell, BuildingData>,
+    pub dirty: bool,
 }
 
 impl BuildingCache {
@@ -123,6 +124,7 @@ impl BuildingCache {
         buildings.iter().for_each(|building_data| {
             self.loaded.insert(building_data.base_data.cell, *building_data);
         });
+        self.dirty = true;
     }
 
     pub fn get_building(&self, cell: &GridCell) -> Option<&BuildingData> {
@@ -475,6 +477,14 @@ impl WorldCache {
         max_distance: i32,
     ) -> (Vec<i64>, Vec<BuildingData>) {
         self.buildings.unload_distant(center, max_distance)
+    }
+
+    pub fn is_buildings_dirty(&self) -> bool {
+        self.buildings.dirty
+    }
+
+    pub fn clear_buildings_dirty(&mut self) {
+        self.buildings.dirty = false;
     }
 
     // OCEAN

--- a/crates/server/src/world/components/natural_building_generator.rs
+++ b/crates/server/src/world/components/natural_building_generator.rs
@@ -81,7 +81,7 @@ impl NaturalBuildingGenerator {
                     .expect(format!("No variations for {:?} type", tree_type).as_str());
 
                 let variant_count = (tree_variations.len()
-                    / (TreeAge::iter().collect::<Vec<TreeAge>>().len() * 6))
+                    / TreeAge::iter().collect::<Vec<TreeAge>>().len())
                     as usize;
                 let tree_variant_idx = rng.random_range(..variant_count);
 

--- a/crates/shared/src/atlas/tree_atlas.rs
+++ b/crates/shared/src/atlas/tree_atlas.rs
@@ -6,36 +6,56 @@ use crate::{TreeAge, TreeTypeEnum};
 
 #[derive(Default, Resource)]
 pub struct TreeAtlas {
+    /// tree_type → list of variant names (used by server for generation)
     pub sprites: HashMap<TreeTypeEnum, Vec<String>>,
+    /// variant name → image handle (individual sprites before packing)
     pub handles: HashMap<String, Handle<Image>>,
+
+    /// variant name → atlas index (after packing)
+    pub variants: HashMap<String, usize>,
+    /// Packed atlas image handle
+    pub atlas_image: Option<Handle<Image>>,
+    /// Atlas layout handle
+    pub atlas_layout: Option<Handle<TextureAtlasLayout>>,
+    /// Atlas grid dimensions
+    pub atlas_cols: u32,
+    pub atlas_rows: u32,
+    pub sprite_size: u32,
 }
 
 impl TreeAtlas {
     pub fn load(&mut self) {
         let tree_types = [
-            (TreeTypeEnum::Cedar, "cedar", 3, 6),
-            // (TreeTypeEnum::Larch, "larch", 3, 6),
-            // (TreeTypeEnum::Oak, "oak", 3, 6),
+            (TreeTypeEnum::Cedar, "cedar", 3),
         ];
 
         self.sprites
-            .extend(tree_types.iter().map(|(tree_type, name, variation, density)| {
+            .extend(tree_types.iter().map(|(tree_type, name, variation)| {
                 let mut variations = Vec::new();
-
                 for age in TreeAge::iter() {
                     for v in 1..=*variation {
-                        for d in 1..=*density {
-                            variations.push(format!("{}_{}_{:02}{:02}", name, age.to_name(), v, d));
-                        }
+                        variations.push(format!("{}_{}_{:02}01", name, age.to_name(), v));
                     }
-                    // let variations = (1..=*variation).(1..=*density).map(|i| format!("{}_{:02}", name, i)).collect();
                 }
-
                 (*tree_type, variations)
             }));
     }
 
     pub fn get_variations(&self, tree_type: TreeTypeEnum) -> Option<&[String]> {
         self.sprites.get(&tree_type).map(|v| v.as_slice())
+    }
+
+    /// Get atlas UV rect for a variant (returns (u_min, v_min, u_max, v_max))
+    pub fn get_atlas_uvs(&self, variant_name: &str) -> Option<[f32; 4]> {
+        let idx = self.variants.get(variant_name)?;
+        let col = (*idx as u32) % self.atlas_cols;
+        let row = (*idx as u32) / self.atlas_cols;
+        let atlas_w = (self.atlas_cols * self.sprite_size) as f32;
+        let atlas_h = (self.atlas_rows * self.sprite_size) as f32;
+        let u_min = (col * self.sprite_size) as f32 / atlas_w;
+        let v_min = (row * self.sprite_size) as f32 / atlas_h;
+        let u_max = ((col + 1) * self.sprite_size) as f32 / atlas_w;
+        let v_max = ((row + 1) * self.sprite_size) as f32 / atlas_h;
+        Some([u_min, v_min, u_max, v_max])
     }
 }


### PR DESCRIPTION
…#75]

- TreeAtlas packs all tree sprites (density 01 only) into a single texture atlas
- Trees rendered as a single merged mesh per rebuild instead of individual entities
- Density is now procedural: 1-8 sub-trees per cell based on density value
- Custom TreeMaterial with alpha test (discard) instead of alpha blend → no overdraw
- Dirty flag on BuildingCache triggers mesh rebuild only when data changes
- Server generates only 15 variants (density 01) instead of 90 (all densities)

Performance: ~4000 entities → 1 mesh, ~45 FPS → 130-135 FPS in dense forest at x100