### PR TITLE
FIX : Restore gizmos rendering after Bevy 0.18 upgrade [#110]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bevy = { version = "0.18.1", default-features = false, features = [
     "bevy_color",
     "bevy_core_pipeline",
     "bevy_gizmos",
+    "bevy_gizmos_render",
     "bevy_image",
     "bevy_input_focus",
     "bevy_mesh",


### PR DESCRIPTION
Add bevy_gizmos_render feature to client Cargo.toml. The rendering backend of bevy_gizmos was split into a separate crate in Bevy 0.18 and must be explicitly enabled when using default-features = false.