### PR TITLE
FIX: Include road SDF and territory contours in HTTP terrain chunk pa…

### DIFF
--- a/crates/client/src/networking/client/game_client.rs
+++ b/crates/client/src/networking/client/game_client.rs
@@ -839,6 +839,7 @@ fn process_pending_terrain_chunks(
     terrain_query: Query<(Entity, &crate::rendering::terrain::components::Terrain)>,
     camera: Query<&Transform, With<crate::camera::MainCamera>>,
     streaming_config: Res<crate::state::resources::StreamingConfig>,
+    mut contour_cache: ResMut<crate::rendering::territory::TerritoryContourCache>,
 ) {
     let Some(ref mut cache) = cache else { return };
     let Some(ref mut units_cache) = units_cache else {
@@ -912,6 +913,8 @@ fn process_pending_terrain_chunks(
                 Vec<shared::grid::CellData>,
                 Vec<shared::BuildingData>,
                 Vec<shared::UnitData>,
+                Option<shared::RoadChunkSdfData>,
+                Vec<shared::protocol::TerritoryContourChunkData>,
             ),
             _,
         ) = match bincode::decode_from_slice(&decompressed, bincode::config::standard()) {
@@ -925,10 +928,15 @@ fn process_pending_terrain_chunks(
             }
         };
 
-        let (terrain_chunk_data, biome_chunk_data, cell_data, building_data, unit_data) = payload;
+        let (mut terrain_chunk_data, biome_chunk_data, cell_data, building_data, unit_data, road_sdf, contours) = payload;
 
         if cache.is_terrain_loaded(&terrain_chunk_data.name, &terrain_chunk_data.id) {
             continue;
+        }
+
+        // Apply road SDF to the terrain chunk before inserting into cache
+        if let Some(road_sdf_data) = road_sdf {
+            terrain_chunk_data.road_sdf_data = Some(road_sdf_data);
         }
 
         let is_update = cache.insert_terrain(&terrain_chunk_data);
@@ -960,6 +968,27 @@ fn process_pending_terrain_chunks(
                 units_cache.set_unit_slot(cell, slot_pos, unit.id);
             }
             units_data_cache.insert_unit(unit.clone());
+        }
+
+        // Insert territory contours into cache
+        for contour_data in &contours {
+            contour_cache.add_contour(
+                msg.chunk_id,
+                contour_data.organization_id,
+                contour_data.segments.iter().map(|s| s.to_contour_segment()).collect(),
+                Color::linear_rgba(
+                    contour_data.border_color.r,
+                    contour_data.border_color.g,
+                    contour_data.border_color.b,
+                    contour_data.border_color.a,
+                ),
+                Color::linear_rgba(
+                    contour_data.fill_color.r,
+                    contour_data.fill_color.g,
+                    contour_data.fill_color.b,
+                    contour_data.fill_color.a,
+                ),
+            );
         }
     }
 

--- a/crates/server/src/http/bulk.rs
+++ b/crates/server/src/http/bulk.rs
@@ -8,9 +8,11 @@ use serde::Deserialize;
 
 use shared::TerrainChunkId;
 use shared::grid::GridConfig;
+use shared::protocol::{TerritoryContourChunkData, ColorData};
 use shared::GameState;
 
 use crate::database::client::DatabaseTables;
+use crate::road::{RoadConfig, compute_intersections, generate_road_sdf};
 use crate::world::resources::WorldGlobalState;
 
 // ─── State ──────────────────────────────────────────────────────────
@@ -77,7 +79,9 @@ pub async fn terrain_chunks(
             let cell_data = db.cells.load_chunk_cells(&cid).await.unwrap_or_default();
             let building_data = db.buildings.load_chunk_buildings(&cid).await.unwrap_or_default();
             let unit_data = db.units.load_chunk_units(cid).await.unwrap_or_default();
-            (cid, terrain_result, cell_data, building_data, unit_data)
+            let road_sdf = load_road_sdf(&db, &cid).await;
+            let contours = load_territory_contours(&db, &cid).await;
+            (cid, terrain_result, cell_data, building_data, unit_data, road_sdf, contours)
         });
     }
 
@@ -87,14 +91,14 @@ pub async fn terrain_chunks(
     let mut chunks_data: Vec<(TerrainChunkId, Vec<u8>)> = Vec::with_capacity(total);
     let mut to_generate: Vec<TerrainChunkId> = Vec::new();
 
-    for (cid, terrain_result, cell_data, building_data, unit_data) in loaded {
+    for (cid, terrain_result, cell_data, building_data, unit_data, road_sdf, contours) in loaded {
         match terrain_result {
             Ok((Some(terrain_data), Some(biome_data))) => {
-                let compressed = encode_terrain_chunk(&terrain_data, &biome_data, &cell_data, &building_data, &unit_data);
+                let compressed = encode_terrain_chunk(&terrain_data, &biome_data, &cell_data, &building_data, &unit_data, &road_sdf, &contours);
                 chunks_data.push((cid, compressed));
             }
             Ok((Some(terrain_data), None)) => {
-                let compressed = encode_terrain_chunk(&terrain_data, &[], &cell_data, &building_data, &unit_data);
+                let compressed = encode_terrain_chunk(&terrain_data, &[], &cell_data, &building_data, &unit_data, &road_sdf, &contours);
                 chunks_data.push((cid, compressed));
             }
             Ok((None, _)) => {
@@ -111,7 +115,9 @@ pub async fn terrain_chunks(
         let (terrain_data, cell_data, building_data) =
             crate::world::systems::generate_chunk_data(chunk_id, world_global_state, db_tables, game_state).await;
         let unit_data = db_tables.units.load_chunk_units(*chunk_id).await.unwrap_or_default();
-        let compressed = encode_terrain_chunk(&terrain_data, &[], &cell_data, &building_data, &unit_data);
+        let road_sdf = load_road_sdf(db_tables, chunk_id).await;
+        let contours = load_territory_contours(db_tables, chunk_id).await;
+        let compressed = encode_terrain_chunk(&terrain_data, &[], &cell_data, &building_data, &unit_data, &road_sdf, &contours);
         chunks_data.push((*chunk_id, compressed));
     }
 
@@ -146,11 +152,50 @@ fn encode_terrain_chunk(
     cell_data: &[shared::grid::CellData],
     building_data: &[shared::BuildingData],
     unit_data: &[shared::UnitData],
+    road_sdf: &Option<shared::RoadChunkSdfData>,
+    contours: &Vec<TerritoryContourChunkData>,
 ) -> Vec<u8> {
-    let payload = (terrain_data, biome_data, cell_data, building_data, unit_data);
+    let payload = (terrain_data, biome_data, cell_data, building_data, unit_data, road_sdf, contours);
     let raw = bincode::encode_to_vec(&payload, bincode::config::standard())
         .expect("Failed to encode terrain chunk payload");
     shared::protocol::bulk_compress::compress(&raw)
+}
+
+async fn load_road_sdf(
+    db_tables: &DatabaseTables,
+    chunk_id: &TerrainChunkId,
+) -> Option<shared::RoadChunkSdfData> {
+    match db_tables.road_segments.load_road_segments_by_chunk_new(chunk_id.x, chunk_id.y).await {
+        Ok(road_segments) if !road_segments.is_empty() => {
+            let config = RoadConfig::default();
+            let intersections = compute_intersections(&road_segments, &config);
+            Some(generate_road_sdf(&road_segments, &intersections, &config, chunk_id.x, chunk_id.y))
+        }
+        _ => None,
+    }
+}
+
+async fn load_territory_contours(
+    db_tables: &DatabaseTables,
+    chunk_id: &TerrainChunkId,
+) -> Vec<TerritoryContourChunkData> {
+    match db_tables.territory_contours.load_chunk_contours(chunk_id).await {
+        Ok(territories) if !territories.is_empty() => {
+            territories.iter().map(|t| {
+                let (border_color, fill_color) = crate::world::territory::generate_org_colors(
+                    t.organization_id,
+                );
+                TerritoryContourChunkData {
+                    organization_id: t.organization_id,
+                    chunk_id: *chunk_id,
+                    segments: t.segments.clone(),
+                    border_color: ColorData::from_array(border_color),
+                    fill_color: ColorData::from_array(fill_color),
+                }
+            }).collect()
+        }
+        _ => vec![],
+    }
 }
 
 // ─── GET /api/world/:name/ocean ─────────────────────────────────────


### PR DESCRIPTION
…yload [#197]

Server (bulk.rs):
- Extended parallel chunk loading to also fetch road segments and territory contours from DB for each chunk
- Added load_road_sdf() — computes road SDF from segments using RoadConfig
- Added load_territory_contours() — converts DB TerritoryChunkData to protocol TerritoryContourChunkData with org colors
- Payload extended from 5-tuple to 7-tuple: (terrain, biomes, cells, buildings, units, road_sdf, contours)

Client (game_client.rs):
- process_pending_terrain_chunks now decodes 7-tuple and accepts TerritoryContourCache as a system parameter
- Road SDF applied to TerrainChunkData before cache insertion
- Territory contours inserted into TerritoryContourCache per chunk

Lightyear receivers for road/contour updates remain for real-time changes.