### PR TITLE
FEAT: Add native .ymir reader and metric u16 height world source [LL-A]

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -115,6 +115,15 @@ fn main() {
         }
         tracing::info!("Using map: {}", map_name);
 
+        // ── World source selection (--world-source flag > WORLD_SOURCE env > azgaar) ──
+        let world_source_flag = args
+            .iter()
+            .find(|arg| arg.starts_with("--world-source="))
+            .map(|arg| arg.trim_start_matches("--world-source=").to_string());
+        let source_kind =
+            world::resources::WorldSourceKind::resolve(world_source_flag.as_deref());
+        tracing::info!("World source: {}", source_kind.as_str());
+
         // ── CLI commands (exit after) ──
         if args.contains(&"--clear".to_string()) {
             tracing::info!("=== Starting World Cleaning ===");
@@ -128,12 +137,12 @@ fn main() {
             std::process::exit(0);
         } else if args.contains(&"--generate-world".to_string()) {
             tracing::info!("=== Starting World Generation ===");
-            world::systems::generate_world(&map_name, &db_tables, &game_state).await;
+            world::systems::generate_world(&map_name, &db_tables, &game_state, source_kind).await;
             tracing::info!("=== Generation Complete - Exiting ===");
             std::process::exit(0);
         } else if args.contains(&"--generate-globals".to_string()) {
             tracing::info!("=== Loading World Globals ===");
-            world::systems::generate_world_globals(&map_name, &db_tables).await;
+            world::systems::generate_world_globals(&map_name, &db_tables, source_kind).await;
             std::process::exit(0);
         } else if args.contains(&"--regen-territory".to_string()) {
             tracing::info!("=== Starting Territory Contours Regeneration ===");
@@ -145,7 +154,7 @@ fn main() {
         // ── World globals ──
         tracing::info!("=== Loading World Globals ===");
         let world_global_state =
-            world::systems::load_or_generate_world_globals(&map_name, &db_tables).await;
+            world::systems::load_or_generate_world_globals(&map_name, &db_tables, source_kind).await;
         tracing::info!("✓ World globals loaded");
 
         // ── Voronoi zones (regenerate if missing) ──

--- a/crates/server/src/world/components/biome_mesh_data.rs
+++ b/crates/server/src/world/components/biome_mesh_data.rs
@@ -346,6 +346,7 @@ impl BiomeMeshData {
         chunk_id: &TerrainChunkId,
         enriched_heightmap: Option<(&[u8], u32, u32)>, // (data, width, height) — u16 LE, flipped
         world_dims: (f32, f32), // (world_width, world_height) from n_chunk * CHUNK_SIZE
+        water_threshold_norm: f32, // normalized sea level; land = height > threshold (0.0 legacy, ~0.5 Ymir)
     ) -> Vec<CellData> {
         let img_w = source_biome_flipped.width();
         let img_h = source_biome_flipped.height();
@@ -492,7 +493,7 @@ impl BiomeMeshData {
                         hm_data, hm_w, hm_h, center_pos, world_w, world_h,
                     );
 
-                    if center_h <= 0.0 {
+                    if center_h <= water_threshold_norm {
                         // Heightmap says water — check if lake or ocean.
                         // Use world_dims for coordinate conversion (not scale)
                         let lx = (center_pos.x / world_w * source_lake.width() as f32) as u32;
@@ -616,7 +617,7 @@ impl BiomeMeshData {
                         let nh = Self::sample_enriched_height(
                             hm_data, hm_w, hm_h, npos, world_w, world_h,
                         );
-                        if nh <= 0.0 {
+                        if nh <= water_threshold_norm {
                             let lx = (npos.x / world_w * source_lake.width() as f32) as u32;
                             let ly = (npos.y / world_h * source_lake.height() as f32) as u32;
                             let is_lake = lx < source_lake.width()

--- a/crates/server/src/world/components/terrain_mesh_data.rs
+++ b/crates/server/src/world/components/terrain_mesh_data.rs
@@ -158,6 +158,11 @@ impl TerrainMeshData {
                 heightmap_values: global_heightmap,
                 world_width,
                 world_height,
+                // Azgaar path has no metric scale; ocean is exactly 0u16.
+                metres_per_cell: 0.0,
+                metres_per_height_unit: 0.0,
+                height_min_m: 0.0,
+                sea_level_norm: 0.0,
                 generated_at: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap()
@@ -186,6 +191,8 @@ impl TerrainMeshData {
             enriched_heightmap_height: terrain_global_data.as_ref().map(|d| d.heightmap_height).unwrap_or(0),
             effective_binary: None,
             effective_binary_smoothed: None,
+            // Azgaar convention: ocean is exactly 0u16 → threshold 0.0.
+            water_threshold_norm: 0.0,
         };
 
         (global_state, terrain_global_data)

--- a/crates/server/src/world/resources/mod.rs
+++ b/crates/server/src/world/resources/mod.rs
@@ -2,8 +2,12 @@ mod sdf_config;
 mod world_config;
 mod world_global_state;
 mod world_maps;
+mod world_source;
+mod ymir_map;
 
 pub use sdf_config::SdfConfig;
 pub use world_config::WorldConfig;
 pub use world_global_state::WorldGlobalState;
 pub use world_maps::WorldMaps;
+pub use world_source::{WorldSource, WorldSourceKind};
+pub use ymir_map::{HeightField, YmirMap};

--- a/crates/server/src/world/resources/world_global_state.rs
+++ b/crates/server/src/world/resources/world_global_state.rs
@@ -56,6 +56,11 @@ pub struct WorldGlobalState {
     /// Gaussian blur on the global image rounds pixel staircases into curves.
     /// No chunk-junction issues since the blur is applied globally before cropping.
     pub effective_binary_smoothed: Option<ImageBuffer<Luma<u8>, Vec<u8>>>,
+
+    /// Normalized sea level in the enriched heightmap (0.0..1.0) — the land/sea
+    /// threshold. `0.0` = legacy Azgaar convention (ocean is exactly `0u16`);
+    /// `0.5` = Ymir full-range encoding (sea level at u16 ≈ 32768).
+    pub water_threshold_norm: f32,
 }
 
 impl WorldGlobalState {
@@ -70,16 +75,20 @@ impl WorldGlobalState {
         let expected_u16_len = w * h * 2;
         let is_u16 = hm_data.len() >= expected_u16_len;
 
+        // Land = normalized height strictly above sea level. For the legacy
+        // Azgaar convention `water_threshold_norm == 0.0`, so this reduces to the
+        // original "> 0" test; for Ymir full-range it is sea_level_norm (~0.5).
+        let threshold = self.water_threshold_norm;
         let mut effective = ImageBuffer::<Luma<u8>, Vec<u8>>::new(w as u32, h as u32);
         for y in 0..h {
             for x in 0..w {
-                // Land = any heightmap value > 0. Ocean is exactly 0u16.
-                let is_land = if is_u16 {
+                let norm = if is_u16 {
                     let idx = (y * w + x) * 2;
-                    u16::from_le_bytes([hm_data[idx], hm_data[idx + 1]]) > 0
+                    u16::from_le_bytes([hm_data[idx], hm_data[idx + 1]]) as f32 / 65535.0
                 } else {
-                    hm_data[y * w + x] > 0
+                    hm_data[y * w + x] as f32 / 255.0
                 };
+                let is_land = norm > threshold;
                 effective.put_pixel(x as u32, y as u32, Luma([if is_land { 255u8 } else { 0u8 }]));
             }
         }

--- a/crates/server/src/world/resources/world_source.rs
+++ b/crates/server/src/world/resources/world_source.rs
@@ -1,0 +1,81 @@
+//! World-source seam (LL-A): selects between the legacy Azgaar PNG bundle and a
+//! native Ymir `.ymir` continent.
+//!
+//! Selection precedence (highest first):
+//!   1. `--world-source=<azgaar|ymir>` CLI flag (passed in as `cli_flag`)
+//!   2. `WORLD_SOURCE` env var (`azgaar` | `ymir`)
+//!   3. default: Azgaar
+//!
+//! The Azgaar path (`WorldMaps`) is kept fully intact and reachable so the two
+//! sources can be A/B-compared during validation.
+
+use super::{WorldMaps, YmirMap};
+
+/// Which world source to load. Cheap, `Copy`, resolved once at startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorldSourceKind {
+    Azgaar,
+    Ymir,
+}
+
+impl WorldSourceKind {
+    /// Parse a source name (case-insensitive). Accepts `azgaar`/`png` and
+    /// `ymir`. Returns `None` for anything else.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "azgaar" | "png" => Some(Self::Azgaar),
+            "ymir" => Some(Self::Ymir),
+            _ => None,
+        }
+    }
+
+    /// Resolve the effective source from (in order): the CLI flag, the
+    /// `WORLD_SOURCE` env var, then the default (Azgaar). Unknown values log a
+    /// warning and fall through to the next tier.
+    pub fn resolve(cli_flag: Option<&str>) -> Self {
+        if let Some(flag) = cli_flag {
+            match Self::parse(flag) {
+                Some(kind) => return kind,
+                None => tracing::warn!(
+                    "Unknown --world-source='{flag}', ignoring (expected azgaar|ymir)"
+                ),
+            }
+        }
+        if let Ok(env) = std::env::var("WORLD_SOURCE") {
+            match Self::parse(&env) {
+                Some(kind) => return kind,
+                None => tracing::warn!(
+                    "Unknown WORLD_SOURCE='{env}', ignoring (expected azgaar|ymir)"
+                ),
+            }
+        }
+        Self::Azgaar
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Azgaar => "azgaar",
+            Self::Ymir => "ymir",
+        }
+    }
+}
+
+/// A loaded world source. Holds the source data for the chosen backend.
+pub enum WorldSource {
+    AzgaarPng(WorldMaps),
+    Ymir(YmirMap),
+}
+
+impl WorldSource {
+    /// Load the source for `map_name` according to `kind`.
+    pub fn load(
+        kind: WorldSourceKind,
+        map_name: &str,
+        seed: u32,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        match kind {
+            WorldSourceKind::Azgaar => Ok(Self::AzgaarPng(WorldMaps::load(map_name, seed)?)),
+            WorldSourceKind::Ymir => Ok(Self::Ymir(YmirMap::load(map_name)?)),
+        }
+    }
+}

--- a/crates/server/src/world/resources/ymir_map.rs
+++ b/crates/server/src/world/resources/ymir_map.rs
@@ -1,0 +1,275 @@
+//! Native reader for Ymir `.ymir` continent directories (LL-A).
+//!
+//! A `.ymir` map is a directory `assets/maps/<name>.ymir/` containing a
+//! `manifest.json` plus typed binary/vector layer files. This module reads the
+//! manifest and the `height` layer (u16 LE, row-major, y=0 = south) into a typed
+//! [`HeightField`] whose values are a *normalized* encoding of metric altitude
+//! (see [`HeightField::metres_of_u16`]).
+//!
+//! Only the `height` layer is consumed in LL-A. Coastline/cliffs (LL-B) and the
+//! `biome.u8` layer (LL-C) are read later; their manifest entries are parsed but
+//! their payloads are ignored here (see the TODOs in [`YmirMap::load`]).
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Supported `format_version` major. Loading errors on any other major.
+const SUPPORTED_FORMAT_MAJOR: u64 = 1;
+
+// ---------------------------------------------------------------------------
+// manifest.json schema (mirrors Ymir 1.x; unknown fields are ignored)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct YmirManifest {
+    pub format_version: String,
+    #[serde(default)]
+    pub ymir_version: Option<String>,
+    pub continent: Continent,
+    #[serde(default)]
+    pub layers: Vec<Layer>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Continent {
+    pub name: String,
+    #[serde(default)]
+    pub seed: Option<i64>,
+    pub grid: Grid,
+    #[serde(default)]
+    pub window_km: f32,
+    pub km_per_cell: f32,
+    pub vertical_scale: VerticalScale,
+    /// Absolute metres at sea level (usually 0.0).
+    pub sea_level_m: f32,
+    /// Metres from sea level to the highest peak.
+    pub max_elevation_m: f32,
+    /// Metres from sea level to the deepest point (positive magnitude).
+    pub max_depth_m: f32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Grid {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VerticalScale {
+    /// Normalized position of sea level in the u16 range (0.0..1.0). 0.5 means
+    /// sea level sits at u16 ≈ 32768.
+    pub sea_level_norm: f32,
+    #[serde(default)]
+    pub altitude_norm_half_range: f32,
+    #[serde(default)]
+    pub depth_scale_m: f32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Layer {
+    pub id: String,
+    #[serde(default)]
+    pub file: Option<String>,
+    #[serde(default)]
+    pub present: bool,
+    #[serde(default)]
+    pub dtype: Option<String>,
+    #[serde(default)]
+    pub width: Option<u32>,
+    #[serde(default)]
+    pub height: Option<u32>,
+    #[serde(default)]
+    pub endianness: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Decoded height layer
+// ---------------------------------------------------------------------------
+
+/// The decoded `height` layer: a normalized u16 field with the metric range
+/// needed to convert cells to metres.
+///
+/// The stored u16 spans the full `[0, 65535]` range and maps linearly onto
+/// `[min_m, max_m]`; sea level sits at `sea_level_norm` of the range.
+pub struct HeightField {
+    pub width: u32,
+    pub height: u32,
+    /// Metres at u16 = 0 (deepest): `sea_level_m - max_depth_m`.
+    pub min_m: f32,
+    /// Metres at u16 = 65535 (highest peak): `sea_level_m + max_elevation_m`.
+    pub max_m: f32,
+    pub km_per_cell: f32,
+    /// Normalized sea level (0.0..1.0); doubles as the land/sea threshold.
+    pub sea_level_norm: f32,
+    /// Row-major, y=0 = south (as authored by Ymir; not yet Y-flipped).
+    pub data: Vec<u16>,
+}
+
+impl HeightField {
+    /// Convert a raw u16 sample to absolute metres.
+    ///
+    /// `metres = min_m + (v / 65535) * (max_m - min_m)`
+    #[inline]
+    pub fn metres_of_u16(&self, v: u16) -> f32 {
+        self.min_m + (v as f32 / 65535.0) * (self.max_m - self.min_m)
+    }
+
+    /// Metres at cell `(x, y)` (no bounds check; caller guarantees in-range).
+    #[inline]
+    pub fn metres_at(&self, x: u32, y: u32) -> f32 {
+        let idx = (y as usize) * (self.width as usize) + (x as usize);
+        self.metres_of_u16(self.data[idx])
+    }
+
+    /// Metres represented by one u16 step: `(max_m - min_m) / 65535`.
+    #[inline]
+    pub fn metres_per_height_unit(&self) -> f32 {
+        (self.max_m - self.min_m) / 65535.0
+    }
+
+    /// Ground-plane metres per grid cell: `km_per_cell * 1000`.
+    #[inline]
+    pub fn metres_per_cell(&self) -> f32 {
+        self.km_per_cell * 1000.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Loaded map
+// ---------------------------------------------------------------------------
+
+pub struct YmirMap {
+    pub manifest: YmirManifest,
+    pub height: HeightField,
+}
+
+impl YmirMap {
+    /// Directory for a given map name: `assets/maps/<name>.ymir`.
+    pub fn dir_for(map_name: &str) -> PathBuf {
+        Path::new("assets/maps").join(format!("{map_name}.ymir"))
+    }
+
+    /// True if `assets/maps/<name>.ymir/manifest.json` exists.
+    pub fn exists(map_name: &str) -> bool {
+        Self::dir_for(map_name).join("manifest.json").is_file()
+    }
+
+    /// Load the manifest and the metric `height` layer.
+    ///
+    /// Errors on: missing/invalid manifest, unsupported `format_version` major,
+    /// missing/absent/non-u16 height layer, or a height file whose byte length
+    /// does not match `width * height * 2`.
+    pub fn load(map_name: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let dir = Self::dir_for(map_name);
+        tracing::info!("Loading Ymir map from {}", dir.display());
+
+        // ── manifest.json ──
+        let manifest_path = dir.join("manifest.json");
+        let manifest_str = std::fs::read_to_string(&manifest_path)
+            .map_err(|e| format!("Ymir: cannot read {}: {e}", manifest_path.display()))?;
+        let manifest: YmirManifest = serde_json::from_str(&manifest_str)
+            .map_err(|e| format!("Ymir: invalid manifest.json: {e}"))?;
+
+        // ── format_version major gate ──
+        let major = manifest
+            .format_version
+            .split('.')
+            .next()
+            .and_then(|s| s.parse::<u64>().ok())
+            .ok_or_else(|| {
+                format!("Ymir: malformed format_version '{}'", manifest.format_version)
+            })?;
+        if major != SUPPORTED_FORMAT_MAJOR {
+            return Err(format!(
+                "Ymir: unsupported format_version major {major} (this build supports {SUPPORTED_FORMAT_MAJOR}.x)"
+            )
+            .into());
+        }
+
+        // ── locate + validate the height layer ──
+        let hl = manifest
+            .layers
+            .iter()
+            .find(|l| l.id == "height")
+            .ok_or("Ymir: manifest has no 'height' layer")?;
+        if !hl.present {
+            return Err("Ymir: 'height' layer is marked not present".into());
+        }
+        if let Some(dtype) = hl.dtype.as_deref() {
+            if dtype != "u16" {
+                return Err(
+                    format!("Ymir: height layer dtype '{dtype}' unsupported (expected u16)").into(),
+                );
+            }
+        }
+        if let Some(endian) = hl.endianness.as_deref() {
+            if endian != "le" {
+                return Err(
+                    format!("Ymir: height layer endianness '{endian}' unsupported (expected le)")
+                        .into(),
+                );
+            }
+        }
+
+        let width = hl.width.unwrap_or(manifest.continent.grid.width);
+        let height = hl.height.unwrap_or(manifest.continent.grid.height);
+        let file = hl.file.clone().unwrap_or_else(|| "height.u16".to_string());
+
+        // ── read + decode u16 LE ──
+        let path = dir.join(&file);
+        let bytes = std::fs::read(&path)
+            .map_err(|e| format!("Ymir: cannot read height layer {}: {e}", path.display()))?;
+        let expected = (width as usize) * (height as usize) * 2;
+        if bytes.len() != expected {
+            return Err(format!(
+                "Ymir: {} is {} bytes, expected {} ({}x{}x2)",
+                path.display(),
+                bytes.len(),
+                expected,
+                width,
+                height
+            )
+            .into());
+        }
+        let data: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+
+        // ── metric range from the continent block (no min_m/max_m on the layer) ──
+        let c = &manifest.continent;
+        let min_m = c.sea_level_m - c.max_depth_m;
+        let max_m = c.sea_level_m + c.max_elevation_m;
+        let field = HeightField {
+            width,
+            height,
+            min_m,
+            max_m,
+            km_per_cell: c.km_per_cell,
+            sea_level_norm: c.vertical_scale.sea_level_norm,
+            data,
+        };
+
+        tracing::info!(
+            "✓ Ymir '{}' loaded: {}x{} height, metric [{:.0}..{:.0}] m, sea_level_norm {:.3}, {:.1} m/cell, {:.4} m/u16-step",
+            c.name,
+            field.width,
+            field.height,
+            field.min_m,
+            field.max_m,
+            field.sea_level_norm,
+            field.metres_per_cell(),
+            field.metres_per_height_unit(),
+        );
+
+        // TODO(LL-B): consume `coastline.geojson` / `cliffs.geojson` layers here.
+        // TODO(LL-C): decode the `biome.u8` layer (semantics ymir.WhittakerBiome@v1),
+        //             plus `temperature.i16` / `precipitation.u16`, into game biomes.
+
+        Ok(Self {
+            manifest,
+            height: field,
+        })
+    }
+}

--- a/crates/server/src/world/systems/world_generation.rs
+++ b/crates/server/src/world/systems/world_generation.rs
@@ -7,9 +7,13 @@ use crate::world::components::NaturalBuildingGenerator;
 use crate::world::components::TerrainMeshData;
 use crate::world::components::generate_global_sdf;
 use crate::world::components::generate_ocean_data;
-use crate::world::resources::{WorldGlobalState, WorldMaps};
+use crate::world::resources::{
+    WorldConfig, WorldGlobalState, WorldMaps, WorldSource, WorldSourceKind, YmirMap,
+};
 use bevy::prelude::*;
 use hexx::HexOrientation;
+use image::{DynamicImage, Rgba};
+use shared::BiomeTypeEnum;
 use shared::BuildingData;
 use shared::GameState;
 use shared::TerrainChunkId;
@@ -35,43 +39,56 @@ pub fn setup_grid_config() -> GridConfig {
 pub async fn generate_world_globals(
     map_name: &str,
     db_tables: &DatabaseTables,
+    source_kind: WorldSourceKind,
 ) -> WorldGlobalState {
-    tracing::info!("=== GENERATING WORLD GLOBALS : {} ===", map_name);
+    tracing::info!(
+        "=== GENERATING WORLD GLOBALS : {} (source: {}) ===",
+        map_name,
+        source_kind.as_str()
+    );
     let start = std::time::Instant::now();
 
-    let maps = WorldMaps::load(map_name, 12345).expect("Failed to load world maps");
     let grid_config = setup_grid_config();
     let scale = Vec2::splat(100.);
 
-    let (mut global_state, terrain_global_data) = TerrainMeshData::generate_globals(
-        map_name,
-        &maps.binary_map,
-        &maps.lake_map,
-        Some(&maps.heightmap),
-        Some(&maps.biome_map),
-        &scale,
-    );
+    let source = WorldSource::load(source_kind, map_name, 12345)
+        .unwrap_or_else(|e| panic!("Failed to load world source ({}): {e}", source_kind.as_str()));
 
-    // Cache source biome RGBA for per-chunk cell sampling
-    let source_biome_flipped = image::imageops::flip_vertical(&maps.biome_map.to_rgba8());
-    tracing::info!(
-        "✓ Source biome RGBA prepared ({}x{})",
-        source_biome_flipped.width(),
-        source_biome_flipped.height()
-    );
+    let (mut global_state, terrain_global_data) = match source {
+        WorldSource::AzgaarPng(maps) => {
+            let (mut global_state, terrain_global_data) = TerrainMeshData::generate_globals(
+                map_name,
+                &maps.binary_map,
+                &maps.lake_map,
+                Some(&maps.heightmap),
+                Some(&maps.biome_map),
+                &scale,
+            );
 
-    let source_lake_flipped = image::imageops::flip_vertical(&maps.lake_map);
-    tracing::info!(
-        "✓ Source lake map prepared ({}x{})",
-        source_lake_flipped.width(),
-        source_lake_flipped.height()
-    );
-    global_state.source_lake_flipped = source_lake_flipped;
+            // Cache source biome RGBA for per-chunk cell sampling
+            let source_biome_flipped = image::imageops::flip_vertical(&maps.biome_map.to_rgba8());
+            tracing::info!(
+                "✓ Source biome RGBA prepared ({}x{})",
+                source_biome_flipped.width(),
+                source_biome_flipped.height()
+            );
 
-    global_state.source_biome_flipped_rgba = Some(source_biome_flipped);
-    global_state.maps = Some(maps);
-    global_state.grid_config = Some(grid_config);
-    global_state.build_effective_binary();
+            let source_lake_flipped = image::imageops::flip_vertical(&maps.lake_map);
+            tracing::info!(
+                "✓ Source lake map prepared ({}x{})",
+                source_lake_flipped.width(),
+                source_lake_flipped.height()
+            );
+            global_state.source_lake_flipped = source_lake_flipped;
+
+            global_state.source_biome_flipped_rgba = Some(source_biome_flipped);
+            global_state.maps = Some(maps);
+            global_state.grid_config = Some(grid_config);
+            global_state.build_effective_binary();
+            (global_state, terrain_global_data)
+        }
+        WorldSource::Ymir(ymir) => build_ymir_globals(map_name, &ymir, grid_config, scale),
+    };
 
     // Save terrain global data (biome + heightmap textures for client)
     if let Some(ref global_data) = terrain_global_data {
@@ -345,11 +362,189 @@ pub async fn generate_world_globals(
     global_state
 }
 
+/// Build world globals from a Ymir metric height field (LL-A).
+///
+/// Consumes the metric u16 `height` layer directly. The enriched heightmap
+/// pipeline (`generate_enriched_heightmap`, steps 1–8 — in particular step 4
+/// coastal-SDF and step 6 FBM detail) is **not** run: `heightmap_values` is the
+/// Ymir u16 copied verbatim (Y-flipped to Bevy Y-up), preserving full range and
+/// bathymetry with no u8 requantise. Land/sea is derived from
+/// `metres > sea_level_m` (temporary; coastline is LL-B, real biomes are LL-C).
+fn build_ymir_globals(
+    map_name: &str,
+    ymir: &YmirMap,
+    grid_config: GridConfig,
+    scale: Vec2,
+) -> (WorldGlobalState, Option<shared::TerrainGlobalData>) {
+    let hf = &ymir.height;
+    let w = hf.width as usize;
+    let h = hf.height as usize;
+    let sea_level_norm = hf.sea_level_norm;
+    let sea_level_m = ymir.manifest.continent.sea_level_m;
+
+    // Placeholder biome palette (LL-C replaces this with the biome.u8 layer).
+    let grass_id = BiomeTypeEnum::Grassland.to_id();
+    let ocean_id = BiomeTypeEnum::Ocean.to_id();
+    let grass_rgba = Rgba([200u8, 214, 143, 255]); // Azgaar Grassland palette color
+    let ocean_rgba = Rgba([0u8, 15, 30, 255]); // Azgaar Ocean palette color
+
+    // Y-flipped R16 heightmap + biome texture + flipped source buffers used by
+    // the per-chunk sampler. Ymir authors y=0 = south; the enriched path flips
+    // vertically at its step 8, so we match that orientation.
+    let mut heightmap_values = vec![0u8; w * h * 2];
+    let mut biome_values = vec![0u8; w * h * 4];
+    let mut source_binary_flipped =
+        image::ImageBuffer::<Luma<u8>, Vec<u8>>::new(hf.width, hf.height);
+    let mut source_biome_flipped_rgba =
+        image::ImageBuffer::<Rgba<u8>, Vec<u8>>::new(hf.width, hf.height);
+
+    for y in 0..h {
+        let src_row = (h - 1 - y) * w; // vertical flip
+        let dst_row = y * w;
+        for x in 0..w {
+            let v = hf.data[src_row + x];
+            let is_land = hf.metres_of_u16(v) > sea_level_m;
+
+            let hb = v.to_le_bytes();
+            let ho = (dst_row + x) * 2;
+            heightmap_values[ho] = hb[0];
+            heightmap_values[ho + 1] = hb[1];
+
+            let (bid, brgba) = if is_land {
+                (grass_id, grass_rgba)
+            } else {
+                (ocean_id, ocean_rgba)
+            };
+            let bo = (dst_row + x) * 4;
+            biome_values[bo] = (bid * 17) as u8; // R = primary biome id * 17
+            biome_values[bo + 1] = (bid * 17) as u8; // G = secondary biome id * 17
+            biome_values[bo + 2] = 0; // B = blend factor
+            biome_values[bo + 3] = 255; // A
+
+            source_binary_flipped
+                .put_pixel(x as u32, y as u32, Luma([if is_land { 255 } else { 0 }]));
+            source_biome_flipped_rgba.put_pixel(x as u32, y as u32, brgba);
+        }
+    }
+
+    // No lake layer in LL-A → empty lake mask.
+    let source_lake_flipped = image::ImageBuffer::<Luma<u8>, Vec<u8>>::new(hf.width, hf.height);
+
+    // Chunk grid — same convention as Azgaar (source px × scale ÷ CHUNK_SIZE).
+    // NOTE: world units are not yet calibrated to metres; metres_per_cell is
+    // stored in TerrainGlobalData for later (LL-B/C) calibration.
+    let scaled_width = hf.width as f32 * scale.x;
+    let scaled_height = hf.height as f32 * scale.y;
+    let n_chunk_x = (scaled_width / constants::CHUNK_SIZE.x).ceil() as i32;
+    let n_chunk_y = (scaled_height / constants::CHUNK_SIZE.y).ceil() as i32;
+    let world_width = n_chunk_x as f32 * constants::CHUNK_SIZE.x;
+    let world_height = n_chunk_y as f32 * constants::CHUNK_SIZE.y;
+
+    // Synthesize a minimal WorldMaps so the ocean/lake global builders and the
+    // `global.maps.unwrap()` in generate_chunk_data are satisfied. Its luma u8
+    // heightmap feeds ONLY the ocean depth texture — never heightmap_values.
+    let maps = build_ymir_worldmaps(ymir, n_chunk_x, n_chunk_y);
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let terrain_global_data = shared::TerrainGlobalData {
+        name: map_name.to_string(),
+        biome_width: hf.width,
+        biome_height: hf.height,
+        biome_values,
+        heightmap_width: hf.width,
+        heightmap_height: hf.height,
+        heightmap_values: heightmap_values.clone(),
+        world_width,
+        world_height,
+        metres_per_cell: hf.metres_per_cell(),
+        metres_per_height_unit: hf.metres_per_height_unit(),
+        height_min_m: hf.min_m,
+        sea_level_norm,
+        generated_at: now,
+    };
+
+    let mut global_state = WorldGlobalState {
+        map_name: map_name.to_string(),
+        maps: Some(maps),
+        source_binary_flipped,
+        source_lake_flipped,
+        n_chunk_x,
+        n_chunk_y,
+        scale,
+        sdf_resolution: 64,
+        max_distance: 150.0,
+        grid_config: Some(grid_config),
+        source_biome_flipped_rgba: Some(source_biome_flipped_rgba),
+        enriched_heightmap: Some(heightmap_values),
+        enriched_heightmap_width: hf.width,
+        enriched_heightmap_height: hf.height,
+        effective_binary: None,
+        effective_binary_smoothed: None,
+        water_threshold_norm: sea_level_norm,
+    };
+    global_state.build_effective_binary();
+
+    tracing::info!(
+        "✓ Ymir globals built (enriched pipeline bypassed — coastal-SDF/FBM skipped): {}x{} height, {}x{} chunks, sea_level_norm {:.3}",
+        hf.width, hf.height, n_chunk_x, n_chunk_y, sea_level_norm
+    );
+
+    (global_state, Some(terrain_global_data))
+}
+
+/// Minimal `WorldMaps` synthesized from a Ymir height field for the ocean/lake
+/// global builders (and the `maps.unwrap()` in chunk generation). Unflipped
+/// (raw source orientation), matching the Azgaar `WorldMaps` convention.
+fn build_ymir_worldmaps(ymir: &YmirMap, n_chunk_x: i32, n_chunk_y: i32) -> WorldMaps {
+    let hf = &ymir.height;
+    let w = hf.width;
+    let h = hf.height;
+    let sea_level_m = ymir.manifest.continent.sea_level_m;
+
+    // u8 heightmap (high byte) — feeds the ocean depth texture only.
+    let heightmap = image::ImageBuffer::<Luma<u8>, Vec<u8>>::from_fn(w, h, |x, y| {
+        Luma([(hf.data[(y * w + x) as usize] >> 8) as u8])
+    });
+    // Land/sea binary (used only by the ocean/lake fallback branch).
+    let binary_map = image::ImageBuffer::<Luma<u8>, Vec<u8>>::from_fn(w, h, |x, y| {
+        Luma([if hf.metres_at(x, y) > sea_level_m { 255 } else { 0 }])
+    });
+    // Empty lake mask (Ymir lake layer not present in LL-A).
+    let lake_map = image::ImageBuffer::<Luma<u8>, Vec<u8>>::new(w, h);
+    // Placeholder biome image (Grassland land / Ocean water) for the legacy batch path.
+    let biome_rgba = image::ImageBuffer::<Rgba<u8>, Vec<u8>>::from_fn(w, h, |x, y| {
+        if hf.metres_at(x, y) > sea_level_m {
+            Rgba([200, 214, 143, 255])
+        } else {
+            Rgba([0, 15, 30, 255])
+        }
+    });
+
+    WorldMaps {
+        heightmap,
+        biome_map: DynamicImage::ImageRgba8(biome_rgba),
+        binary_map,
+        lake_map,
+        config: WorldConfig {
+            map_width: w,
+            map_height: h,
+            chunks_x: n_chunk_x.max(0) as u32,
+            chunks_y: n_chunk_y.max(0) as u32,
+            seed: ymir.manifest.continent.seed.unwrap_or(0) as u32,
+        },
+    }
+}
+
 /// Load cached world globals from DB, or generate them if not found.
 /// This is the normal server startup path.
 pub async fn load_or_generate_world_globals(
     map_name: &str,
     db_tables: &DatabaseTables,
+    source_kind: WorldSourceKind,
 ) -> WorldGlobalState {
     let has_globals = db_tables
         .terrain_global_data
@@ -370,6 +565,23 @@ pub async fn load_or_generate_world_globals(
             );
         }
         let t = std::time::Instant::now();
+
+        // Ymir: the .ymir source is authoritative and cheap to reload; rebuild
+        // the in-memory globals from it (the cached ocean/lake in DB are reused,
+        // and the heightmap is deterministic so it matches the cached copy).
+        if source_kind == WorldSourceKind::Ymir {
+            let ymir = YmirMap::load(map_name).expect("Failed to load Ymir map");
+            let grid_config = setup_grid_config();
+            let scale = Vec2::splat(100.);
+            let (global_state, _tgd) = build_ymir_globals(map_name, &ymir, grid_config, scale);
+            tracing::info!(
+                "✓ Ymir world globals rebuilt in {:?} ({}x{} chunks)",
+                t.elapsed(),
+                global_state.n_chunk_x,
+                global_state.n_chunk_y
+            );
+            return global_state;
+        }
 
         let maps = WorldMaps::load(map_name, 12345).expect("Failed to load world maps");
         let grid_config = setup_grid_config();
@@ -415,6 +627,8 @@ pub async fn load_or_generate_world_globals(
             enriched_heightmap_height: ehm_h,
             effective_binary: None,
             effective_binary_smoothed: None,
+            // Azgaar convention: ocean is exactly 0u16 → threshold 0.0.
+            water_threshold_norm: 0.0,
         };
 
         global_state.build_effective_binary();
@@ -428,7 +642,7 @@ pub async fn load_or_generate_world_globals(
         global_state
     } else {
         tracing::info!("No cached globals found, generating from scratch...");
-        generate_world_globals(map_name, db_tables).await
+        generate_world_globals(map_name, db_tables, source_kind).await
     }
 }
 
@@ -588,6 +802,7 @@ pub async fn generate_chunk_data(
                 global.n_chunk_x as f32 * constants::CHUNK_SIZE.x,
                 global.n_chunk_y as f32 * constants::CHUNK_SIZE.y,
             ),
+            global.water_threshold_norm,
         )
     } else {
         vec![]
@@ -685,11 +900,16 @@ pub async fn generate_chunk_data(
 
 /// Generate everything in batch (convenience for dev/testing).
 /// Uses generate_world_globals + generate_chunk_data for each chunk.
-pub async fn generate_world(map_name: &str, db_tables: &DatabaseTables, game_state: &GameState) {
+pub async fn generate_world(
+    map_name: &str,
+    db_tables: &DatabaseTables,
+    game_state: &GameState,
+    source_kind: WorldSourceKind,
+) {
     tracing::info!("Starting full world generation...");
     let start = std::time::Instant::now();
 
-    let global_state = generate_world_globals(map_name, db_tables).await;
+    let global_state = generate_world_globals(map_name, db_tables, source_kind).await;
     let global_maps = global_state.maps.as_ref().unwrap();
     let global_grid_config = global_state.grid_config.as_ref().unwrap();
 

--- a/crates/shared/src/types/terrain/terrain_global_data.rs
+++ b/crates/shared/src/types/terrain/terrain_global_data.rs
@@ -28,6 +28,16 @@ pub struct TerrainGlobalData {
     pub world_width: f32,
     pub world_height: f32,
 
+    /// Ground-plane metres per source grid cell (0.0 = unknown / legacy Azgaar).
+    pub metres_per_cell: f32,
+    /// Metres represented by one R16 height step (0.0 = unknown / legacy Azgaar).
+    pub metres_per_height_unit: f32,
+    /// Absolute metres at R16 value 0 (offset for `metres = height_min_m + u16 * metres_per_height_unit`).
+    pub height_min_m: f32,
+    /// Normalized sea level in the R16 range, i.e. the land/sea threshold.
+    /// 0.0 = legacy convention (ocean is exactly 0); 0.5 = Ymir full-range (sea level mid-range).
+    pub sea_level_norm: f32,
+
     pub generated_at: u64,
 }
 
@@ -43,6 +53,10 @@ impl Default for TerrainGlobalData {
             heightmap_values: vec![0, 128], // single u16 LE pixel
             world_width: 1.0,
             world_height: 1.0,
+            metres_per_cell: 0.0,
+            metres_per_height_unit: 0.0,
+            height_min_m: 0.0,
+            sea_level_norm: 0.0,
             generated_at: 0,
         }
     }


### PR DESCRIPTION
Introduce an alternate world-generation source that consumes Ymir's metric `height` layer directly, alongside the existing Azgaar PNG pipeline (kept intact for A/B validation).

- ymir_map.rs: serde reader for `<map>.ymir/manifest.json` + the `height` layer (u16 LE), validating the format_version major. HeightField exposes the metres<->u16 mapping (min_m/max_m from the continent block, since the layer carries no min_m/max_m) and metres_per_cell / metres_per_height_unit.
- world_source.rs: WorldSource { AzgaarPng, Ymir } seam + WorldSourceKind resolved from `--world-source=<azgaar|ymir>` > WORLD_SOURCE env > azgaar.
- generate_world_globals branches on the source; the Ymir path bypasses the enriched heightmap pipeline entirely (in particular step 4 coastal-SDF and step 6 FBM detail), copying the metric u16 verbatim into heightmap_values (Y-flipped, full range preserved, no u8 requantise).
- Land/sea becomes sea-level-aware: WorldGlobalState.water_threshold_norm (0.0 Azgaar, sea_level_norm for Ymir) replaces the hard-coded "height > 0" test in build_effective_binary and biome_mesh_data. Ymir land/sea is derived from metres > sea_level_m.
- TerrainGlobalData gains metres_per_cell, metres_per_height_unit, height_min_m and sea_level_norm for later shader/gameplay use.
- Temporary placeholder biome (Grassland land / Ocean water) so generation runs end to end; TODO markers left for coastline (LL-B) and biome.u8 (LL-C).

Verified: cargo build (debug+release) green, heightmap_enriched tests pass, and `--world-source=ymir --map=seed42_2048 --generate-globals` produces 228x271 chunks with 35.3% land (matching the height histogram) and no enriched-pipeline steps.