### PR TITLE
FEAT: Vector coastline SDF and physical slope shader on the Ymir path…

### DIFF
--- a/assets/shaders/terrain_signed_sdf_painterly.wgsl
+++ b/assets/shaders/terrain_signed_sdf_painterly.wgsl
@@ -24,6 +24,8 @@
 @group(2) @binding(21) var<uniform> debug_params: vec4<f32>; // x = slope_debug_enabled
 @group(2) @binding(22) var ocean_sdf_texture: texture_2d<f32>;
 @group(2) @binding(23) var ocean_sdf_sampler: sampler;
+// LL-B: metric scale for physical slope on the Ymir path. x=0 on the Azgaar path.
+@group(2) @binding(24) var<uniform> metric_params: vec4<f32>; // x=metres_per_cell, y=metres_per_height_unit, z=sea_level_norm, w=cliff_threshold_deg
 
 // ============================================================================
 // CONSTANTES PALETTE PAINTERLY
@@ -199,6 +201,38 @@ fn sample_height(uv: vec2<f32>) -> f32 {
 fn compute_sobel_gradients(uv: vec2<f32>, world_pos: vec2<f32>) -> vec2<f32> {
     let hm_dims = vec2<f32>(textureDimensions(heightmap_texture));
     let hm_texel = 1.0 / hm_dims;
+
+    let metres_per_cell = metric_params.x;
+
+    if (metres_per_cell > 0.0) {
+        // ── Ymir path: true physical slope (rise/run), no FBM jitter ──
+        // The heightmap is 1 texel per Ymir cell (not ×4 upscaled), so a 1-texel
+        // Sobel step spans exactly `metres_per_cell` metres of ground.
+        let step = hm_texel;
+        let uv_min = hm_texel * 0.5;
+        let uv_max = 1.0 - hm_texel * 0.5;
+
+        let h_l = sample_height(clamp(uv + vec2<f32>(-step.x, 0.0), uv_min, uv_max));
+        let h_r = sample_height(clamp(uv + vec2<f32>( step.x, 0.0), uv_min, uv_max));
+        let h_d = sample_height(clamp(uv + vec2<f32>(0.0, -step.y), uv_min, uv_max));
+        let h_u = sample_height(clamp(uv + vec2<f32>(0.0,  step.y), uv_min, uv_max));
+        let h_ld = sample_height(clamp(uv + vec2<f32>(-step.x, -step.y), uv_min, uv_max));
+        let h_ru = sample_height(clamp(uv + vec2<f32>( step.x,  step.y), uv_min, uv_max));
+        let h_lu = sample_height(clamp(uv + vec2<f32>(-step.x,  step.y), uv_min, uv_max));
+        let h_rd = sample_height(clamp(uv + vec2<f32>( step.x, -step.y), uv_min, uv_max));
+
+        // Sobel central difference in NORMALISED height per 1-cell step.
+        let dz_norm_x = ((h_rd + 2.0 * h_r + h_ru) - (h_ld + 2.0 * h_l + h_lu)) / 8.0;
+        let dz_norm_y = -((h_lu + 2.0 * h_u + h_ru) - (h_ld + 2.0 * h_d + h_rd)) / 8.0;
+
+        // rise (metres) = Δh_norm · 65535 · metres_per_height_unit
+        // run  (metres) = 1 cell · metres_per_cell   → slope = rise/run (tan θ)
+        let rise_scale = 65535.0 * metric_params.y;
+        let inv_run = rise_scale / metres_per_cell;
+        return vec2<f32>(dz_norm_x * inv_run, dz_norm_y * inv_run);
+    }
+
+    // ── Azgaar path (unchanged): FBM-jittered UVs + unitless slope_scale = 3.0 ──
     let step = hm_texel * 2.0;
 
     let noise_offset = vec2<f32>(
@@ -726,13 +760,23 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         switch debug_base {
             // --- 1: Slope classes ---
             case 1u: {
-                if (height > 0.0) {
+                if (height > metric_params.z) {
                     let slope = compute_slope_magnitude(global_uv, world_pos);
                     debug_color = vec3<f32>(0.31, 0.63, 0.31);
-                    debug_color = mix(debug_color, vec3<f32>(0.71, 0.71, 0.24), smoothstep(0.04, 0.06, slope));
-                    debug_color = mix(debug_color, vec3<f32>(0.86, 0.55, 0.16), smoothstep(0.13, 0.17, slope));
-                    debug_color = mix(debug_color, vec3<f32>(0.78, 0.20, 0.20), smoothstep(0.33, 0.37, slope));
-                    debug_color = mix(debug_color, vec3<f32>(0.55, 0.16, 0.55), smoothstep(0.58, 0.62, slope));
+                    if (metric_params.x > 0.0) {
+                        // Ymir: physical slope classes in DEGREES (5/15/30/45°)
+                        let deg = degrees(atan(slope));
+                        debug_color = mix(debug_color, vec3<f32>(0.71, 0.71, 0.24), smoothstep(4.0, 6.0, deg));
+                        debug_color = mix(debug_color, vec3<f32>(0.86, 0.55, 0.16), smoothstep(14.0, 16.0, deg));
+                        debug_color = mix(debug_color, vec3<f32>(0.78, 0.20, 0.20), smoothstep(29.0, 31.0, deg));
+                        debug_color = mix(debug_color, vec3<f32>(0.55, 0.16, 0.55), smoothstep(44.0, 46.0, deg));
+                    } else {
+                        // Azgaar: original unitless calibration
+                        debug_color = mix(debug_color, vec3<f32>(0.71, 0.71, 0.24), smoothstep(0.04, 0.06, slope));
+                        debug_color = mix(debug_color, vec3<f32>(0.86, 0.55, 0.16), smoothstep(0.13, 0.17, slope));
+                        debug_color = mix(debug_color, vec3<f32>(0.78, 0.20, 0.20), smoothstep(0.33, 0.37, slope));
+                        debug_color = mix(debug_color, vec3<f32>(0.55, 0.16, 0.55), smoothstep(0.58, 0.62, slope));
+                    }
                 }
             }
             // --- 2: Altitude bands ---
@@ -851,9 +895,17 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     if (heightmap_params.x > 0.5) {
         slope_magnitude = compute_slope_magnitude(global_uv, world_pos);
     }
-    // Rock appears on steep slopes (~45°+). Calibrated for enriched heightmap
-    // where slope_magnitude ~0.04 = moderate hill, ~0.10 = cliff.
-    let rock_factor = smoothstep(0.04, 0.10, slope_magnitude);
+    // Rock appears on steep slopes. Ymir path: slope_magnitude is true tan(θ), so
+    // threshold in DEGREES around metric_params.w (cliff_threshold_deg). Azgaar
+    // path (unitless): keep the original 0.04–0.10 calibration.
+    var rock_factor: f32;
+    if (metric_params.x > 0.0) {
+        let slope_deg = degrees(atan(slope_magnitude));
+        let cliff_deg = metric_params.w;
+        rock_factor = smoothstep(cliff_deg * 0.7, cliff_deg, slope_deg);
+    } else {
+        rock_factor = smoothstep(0.04, 0.10, slope_magnitude);
+    }
 
     // === Lake: discard water, render bank ===
     var lake_bank_factor = 0.0;

--- a/crates/client/src/rendering/terrain/materials/terrain_material.rs
+++ b/crates/client/src/rendering/terrain/materials/terrain_material.rs
@@ -75,6 +75,23 @@ pub struct TerrainMaterial {
     #[texture(22)]
     #[sampler(23, sampler_type = "filtering")]
     pub ocean_sdf_texture: Handle<Image>,
+
+    /// LL-B: metric scale for physical slope on the Ymir path.
+    /// `metres_per_cell == 0.0` selects the legacy (Azgaar) shader slope path.
+    #[uniform(24)]
+    pub metric_params: MetricParams,
+}
+
+#[derive(Clone, Copy, Default, ShaderType)]
+pub struct MetricParams {
+    /// Ground metres per source grid cell (0.0 = legacy Azgaar → old slope path).
+    pub metres_per_cell: f32,
+    /// Metres per one R16 height step (`(max_m - min_m) / 65535`).
+    pub metres_per_height_unit: f32,
+    /// Normalized sea level (land/sea threshold): 0.0 Azgaar, ~0.5 Ymir.
+    pub sea_level_norm: f32,
+    /// Cliff/rock onset threshold in degrees (Ymir slope shading).
+    pub cliff_threshold_deg: f32,
 }
 
 #[derive(Clone, Copy, Default, ShaderType)]
@@ -211,6 +228,7 @@ impl Default for TerrainMaterial {
             lake_params: LakeParams::default(),
             debug_params: DebugParams::default(),
             ocean_sdf_texture: Handle::default(),
+            metric_params: MetricParams::default(),
         }
     }
 }

--- a/crates/client/src/rendering/terrain/systems.rs
+++ b/crates/client/src/rendering/terrain/systems.rs
@@ -20,7 +20,7 @@ use super::materials::TerrainMaterial;
 use crate::camera::MainCamera;
 use crate::rendering::terrain::components::TreeChunkMesh;
 use crate::rendering::terrain::materials::{
-    BiomeParams, ChunkInfo, HeightmapParams, LakeParams, RoadParams, SdfParams, TreeMaterial,
+    BiomeParams, ChunkInfo, HeightmapParams, LakeParams, MetricParams, RoadParams, SdfParams, TreeMaterial,
 };
 use crate::state::resources::{ConnectionStatus, WorldCache};
 
@@ -281,6 +281,19 @@ pub fn spawn_terrain(
                 (dummy, HeightmapParams::default())
             };
 
+        // LL-B: metric scale for physical slope (Ymir path). Azgaar globals carry
+        // metres_per_cell == 0.0, which keeps the legacy shader slope path.
+        let metric_params = if let Some(global) = world_cache.get_terrain_global() {
+            MetricParams {
+                metres_per_cell: global.metres_per_cell,
+                metres_per_height_unit: global.metres_per_height_unit,
+                sea_level_norm: global.sea_level_norm,
+                cliff_threshold_deg: if global.metres_per_cell > 0.0 { 35.0 } else { 0.0 },
+            }
+        } else {
+            MetricParams::default()
+        };
+
         let (lake_sdf_texture, lake_params) = if let Some(lh) = world_cache.get_lake_sdf_handle() {
             (
                 lh.clone(),
@@ -381,6 +394,7 @@ pub fn spawn_terrain(
                 lake_sdf_texture: lake_sdf_texture.clone(),
                 lake_params,
                 ocean_sdf_texture: ocean_sdf_texture.clone(),
+                metric_params,
                 ..default()
             }))
         } else {
@@ -423,6 +437,7 @@ pub fn spawn_terrain(
                 lake_sdf_texture: lake_sdf_texture.clone(),
                 lake_params,
                 ocean_sdf_texture: ocean_sdf_texture.clone(),
+                metric_params,
                 ..default()
             }))
         };

--- a/crates/server/src/world/components/coastal_sdf.rs
+++ b/crates/server/src/world/components/coastal_sdf.rs
@@ -1,0 +1,159 @@
+//! Signed coastal distance field from vector coastline polylines (LL-B, Ymir path).
+//!
+//! Replaces the Gaussian-smoothed pixel-mask EDT with a distance computed
+//! directly from Ymir's `coastline.geojson` polylines. Output matches the
+//! existing SDF byte convention (`((signed/max_distance + 1) * 0.5 * 255)`,
+//! i.e. 0 = deep water, 128 = coast, 255 = far inland) so downstream ocean/lake
+//! shaders and the `beach_start/beach_end` thresholds are unchanged.
+
+use image::{ImageBuffer, Luma};
+use rayon::prelude::*;
+
+/// One coast segment in **output-texel** space.
+struct Seg {
+    ax: f32,
+    ay: f32,
+    bx: f32,
+    by: f32,
+}
+
+#[inline]
+fn dist_point_seg(px: f32, py: f32, s: &Seg) -> f32 {
+    let abx = s.bx - s.ax;
+    let aby = s.by - s.ay;
+    let apx = px - s.ax;
+    let apy = py - s.ay;
+    let ab2 = abx * abx + aby * aby;
+    let t = if ab2 > 0.0 {
+        ((apx * abx + apy * aby) / ab2).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let cx = s.ax + t * abx;
+    let cy = s.ay + t * aby;
+    let dx = px - cx;
+    let dy = py - cy;
+    (dx * dx + dy * dy).sqrt()
+}
+
+/// Compute the signed coastal distance field from `polylines_cell` (coastline
+/// polylines in Ymir **cell space**, y=0 = south) at resolution `out_w × out_h`.
+///
+/// - Distances are measured in **output texels** and normalized by
+///   `max_distance_texels` (match the ocean SDF's `max_distance`).
+/// - Sign comes from `land_mask` (the Ymir `effective_binary`: land = height >
+///   sea level); positive inland, negative in water.
+/// - Polyline coords are mapped cell→texel with the **same vertical flip** as the
+///   LL-A heightmap (cell y=0/south → bottom of the display-oriented texture),
+///   so the coast lines up with the land mask and heightmap.
+pub fn coastal_signed_distance_field(
+    polylines_cell: &[Vec<[f32; 2]>],
+    grid_w: u32,
+    grid_h: u32,
+    out_w: usize,
+    out_h: usize,
+    max_distance_texels: f32,
+    land_mask: &ImageBuffer<Luma<u8>, Vec<u8>>,
+) -> Vec<u8> {
+    let sx = out_w as f32 / grid_w as f32;
+    let sy = out_h as f32 / grid_h as f32;
+    let gh = grid_h as f32;
+
+    // cell (cx, cy_south) → output texel (display-oriented, north-up)
+    let to_texel = |c: &[f32; 2]| -> (f32, f32) {
+        let tx = c[0] * sx;
+        let ty = (gh - c[1]) * sy; // vertical flip: south (y=0) → bottom
+        (tx, ty)
+    };
+
+    // Flatten polylines into segments in texel space.
+    let mut segs: Vec<Seg> = Vec::new();
+    for line in polylines_cell {
+        for w in line.windows(2) {
+            let (ax, ay) = to_texel(&w[0]);
+            let (bx, by) = to_texel(&w[1]);
+            segs.push(Seg { ax, ay, bx, by });
+        }
+    }
+    if segs.is_empty() {
+        // No coastline → everything saturates to the sign of the land mask.
+        return sign_only(land_mask, out_w, out_h);
+    }
+
+    // Uniform bin spatial index: bin size = search radius, so each query texel
+    // only scans its own bin ± 1 (3×3 bins).
+    let bin = max_distance_texels.ceil().max(1.0);
+    let nbx = ((out_w as f32) / bin).ceil() as usize + 1;
+    let nby = ((out_h as f32) / bin).ceil() as usize + 1;
+    let mut bins: Vec<Vec<u32>> = vec![Vec::new(); nbx * nby];
+    for (i, s) in segs.iter().enumerate() {
+        let min_bx = ((s.ax.min(s.bx)) / bin).floor().max(0.0) as usize;
+        let max_bx = ((s.ax.max(s.bx)) / bin).floor().min((nbx - 1) as f32) as usize;
+        let min_by = ((s.ay.min(s.by)) / bin).floor().max(0.0) as usize;
+        let max_by = ((s.ay.max(s.by)) / bin).floor().min((nby - 1) as f32) as usize;
+        for by in min_by..=max_by {
+            for bx in min_bx..=max_bx {
+                bins[by * nbx + bx].push(i as u32);
+            }
+        }
+    }
+
+    let mask_w = land_mask.width();
+    let mask_h = land_mask.height();
+
+    (0..out_w * out_h)
+        .into_par_iter()
+        .map(|idx| {
+            let tx = (idx % out_w) as f32 + 0.5;
+            let ty = (idx / out_w) as f32 + 0.5;
+
+            // nearest-distance search over the 3×3 bin neighborhood
+            let cbx = (tx / bin).floor() as isize;
+            let cby = (ty / bin).floor() as isize;
+            let mut best = max_distance_texels;
+            for dby in -1..=1 {
+                for dbx in -1..=1 {
+                    let bx = cbx + dbx;
+                    let by = cby + dby;
+                    if bx < 0 || by < 0 || bx as usize >= nbx || by as usize >= nby {
+                        continue;
+                    }
+                    for &si in &bins[by as usize * nbx + bx as usize] {
+                        let d = dist_point_seg(tx, ty, &segs[si as usize]);
+                        if d < best {
+                            best = d;
+                        }
+                    }
+                }
+            }
+
+            // Sign from the land mask (display-oriented, same as output).
+            let mx = ((idx % out_w) as f32 / out_w as f32 * mask_w as f32) as u32;
+            let my = ((idx / out_w) as f32 / out_h as f32 * mask_h as f32) as u32;
+            let is_land = land_mask
+                .get_pixel(mx.min(mask_w - 1), my.min(mask_h - 1))[0]
+                > 128;
+
+            let signed = if is_land { best } else { -best };
+            let normalized = (signed / max_distance_texels).clamp(-1.0, 1.0);
+            ((normalized + 1.0) * 0.5 * 255.0) as u8
+        })
+        .collect()
+}
+
+/// Fallback when there are no polylines: encode the saturated sign of the mask.
+fn sign_only(land_mask: &ImageBuffer<Luma<u8>, Vec<u8>>, out_w: usize, out_h: usize) -> Vec<u8> {
+    let mask_w = land_mask.width();
+    let mask_h = land_mask.height();
+    (0..out_w * out_h)
+        .into_par_iter()
+        .map(|idx| {
+            let mx = ((idx % out_w) as f32 / out_w as f32 * mask_w as f32) as u32;
+            let my = ((idx / out_w) as f32 / out_h as f32 * mask_h as f32) as u32;
+            let is_land = land_mask
+                .get_pixel(mx.min(mask_w - 1), my.min(mask_h - 1))[0]
+                > 128;
+            if is_land { 255u8 } else { 0u8 }
+        })
+        .collect()
+}

--- a/crates/server/src/world/components/mod.rs
+++ b/crates/server/src/world/components/mod.rs
@@ -1,5 +1,6 @@
 mod biome_mesh_data;
 mod biome_triangulation;
+mod coastal_sdf;
 pub mod heightmap_enriched;
 mod mesh_data;
 mod natural_building_generator;
@@ -8,6 +9,7 @@ mod territory;
 
 pub use biome_mesh_data::BiomeMeshData;
 pub use biome_triangulation::BiomeTriangulation;
+pub use coastal_sdf::coastal_signed_distance_field;
 pub use mesh_data::MeshData;
 pub use natural_building_generator::NaturalBuildingGenerator;
 pub use terrain_mesh_data::{TerrainMeshData, generate_global_sdf, generate_ocean_data};

--- a/crates/server/src/world/components/terrain_mesh_data.rs
+++ b/crates/server/src/world/components/terrain_mesh_data.rs
@@ -193,6 +193,7 @@ impl TerrainMeshData {
             effective_binary_smoothed: None,
             // Azgaar convention: ocean is exactly 0u16 → threshold 0.0.
             water_threshold_norm: 0.0,
+            coastline_cells: Vec::new(),
         };
 
         (global_state, terrain_global_data)

--- a/crates/server/src/world/resources/world_global_state.rs
+++ b/crates/server/src/world/resources/world_global_state.rs
@@ -61,12 +61,22 @@ pub struct WorldGlobalState {
     /// threshold. `0.0` = legacy Azgaar convention (ocean is exactly `0u16`);
     /// `0.5` = Ymir full-range encoding (sea level at u16 ≈ 32768).
     pub water_threshold_norm: f32,
+
+    /// Ymir sea-level coastline polylines in **cell space** (y=0 = south), used to
+    /// build the coastal SDF from vectors instead of a smoothed pixel mask (LL-B).
+    /// Empty on the Azgaar path (and on Ymir maps without a coastline layer).
+    pub coastline_cells: Vec<Vec<[f32; 2]>>,
 }
 
 impl WorldGlobalState {
     /// Generate the effective binary map from the enriched heightmap.
     /// Must be called after enriched_heightmap is populated.
-    pub fn build_effective_binary(&mut self) {
+    ///
+    /// `smoothed` controls whether the Gaussian-blurred `effective_binary_smoothed`
+    /// is produced for render SDFs. The Azgaar path passes `true`; the Ymir path
+    /// passes `false` (its coast comes from the vector coastline SDF, so the σ=5
+    /// mask blur + re-threshold are skipped — LL-B).
+    pub fn build_effective_binary(&mut self, smoothed: bool) {
         let Some(ref hm_data) = self.enriched_heightmap else {
             return;
         };
@@ -100,44 +110,49 @@ impl WorldGlobalState {
         );
         // Build smoothed version for rendering SDFs (organic coastlines).
         // Applied globally — no chunk-junction issues since both chunks crop
-        // from the same blurred image.
-        let sigma = 5.0f32;
-        let radius = (sigma * 2.5).ceil() as i32;
-        let ksize = (2 * radius + 1) as usize;
-        let mut kernel = vec![0.0f32; ksize];
-        let mut ksum = 0.0f32;
-        for i in 0..ksize {
-            let xf = (i as i32 - radius) as f32;
-            kernel[i] = (-xf * xf / (2.0 * sigma * sigma)).exp();
-            ksum += kernel[i];
-        }
-        for v in kernel.iter_mut() { *v /= ksum; }
+        // from the same blurred image. Skipped on the Ymir path (LL-B): its
+        // coastline comes from the vector SDF, not a blurred pixel mask.
+        if smoothed {
+            let sigma = 5.0f32;
+            let radius = (sigma * 2.5).ceil() as i32;
+            let ksize = (2 * radius + 1) as usize;
+            let mut kernel = vec![0.0f32; ksize];
+            let mut ksum = 0.0f32;
+            for i in 0..ksize {
+                let xf = (i as i32 - radius) as f32;
+                kernel[i] = (-xf * xf / (2.0 * sigma * sigma)).exp();
+                ksum += kernel[i];
+            }
+            for v in kernel.iter_mut() { *v /= ksum; }
 
-        let mut tmp = vec![0.0f32; w * h];
-        for y in 0..h {
-            for x in 0..w {
-                let mut s = 0.0f32;
-                for k in -radius..=radius {
-                    let sx = (x as i32 + k).clamp(0, w as i32 - 1) as usize;
-                    s += (effective.get_pixel(sx as u32, y as u32)[0] as f32 / 255.0)
-                        * kernel[(k + radius) as usize];
+            let mut tmp = vec![0.0f32; w * h];
+            for y in 0..h {
+                for x in 0..w {
+                    let mut s = 0.0f32;
+                    for k in -radius..=radius {
+                        let sx = (x as i32 + k).clamp(0, w as i32 - 1) as usize;
+                        s += (effective.get_pixel(sx as u32, y as u32)[0] as f32 / 255.0)
+                            * kernel[(k + radius) as usize];
+                    }
+                    tmp[y * w + x] = s;
                 }
-                tmp[y * w + x] = s;
             }
-        }
-        let mut smoothed = ImageBuffer::<Luma<u8>, Vec<u8>>::new(w as u32, h as u32);
-        for y in 0..h {
-            for x in 0..w {
-                let mut s = 0.0f32;
-                for k in -radius..=radius {
-                    let sy = (y as i32 + k).clamp(0, h as i32 - 1) as usize;
-                    s += tmp[sy * w + x] * kernel[(k + radius) as usize];
+            let mut smoothed_img = ImageBuffer::<Luma<u8>, Vec<u8>>::new(w as u32, h as u32);
+            for y in 0..h {
+                for x in 0..w {
+                    let mut s = 0.0f32;
+                    for k in -radius..=radius {
+                        let sy = (y as i32 + k).clamp(0, h as i32 - 1) as usize;
+                        s += tmp[sy * w + x] * kernel[(k + radius) as usize];
+                    }
+                    smoothed_img.put_pixel(x as u32, y as u32, Luma([if s > 0.5 { 255u8 } else { 0u8 }]));
                 }
-                smoothed.put_pixel(x as u32, y as u32, Luma([if s > 0.5 { 255u8 } else { 0u8 }]));
             }
+            tracing::info!("✓ Smoothed effective binary for render (sigma={}, {}x{})", sigma, w, h);
+            self.effective_binary_smoothed = Some(smoothed_img);
+        } else {
+            self.effective_binary_smoothed = None;
         }
-        tracing::info!("✓ Smoothed effective binary for render (sigma={}, {}x{})", sigma, w, h);
-        self.effective_binary_smoothed = Some(smoothed);
 
         self.effective_binary = Some(effective);
     }

--- a/crates/server/src/world/resources/ymir_map.rs
+++ b/crates/server/src/world/resources/ymir_map.rs
@@ -142,6 +142,10 @@ impl HeightField {
 pub struct YmirMap {
     pub manifest: YmirManifest,
     pub height: HeightField,
+    /// Sea-level coastline polylines in **cell space** (x in [0,width], y in
+    /// [0,height], y=0 = south), from `coastline.geojson`. Empty if the layer is
+    /// absent or `present: false` (callers then fall back to the height threshold).
+    pub coastline: Vec<Vec<[f32; 2]>>,
 }
 
 impl YmirMap {
@@ -263,13 +267,109 @@ impl YmirMap {
             field.metres_per_height_unit(),
         );
 
-        // TODO(LL-B): consume `coastline.geojson` / `cliffs.geojson` layers here.
+        // ── coastline.geojson (LL-B): sea-level MultiLineString in cell space ──
+        let coastline = load_coastline(&dir, &manifest);
+        tracing::info!(
+            "✓ Ymir coastline: {} polylines ({} points)",
+            coastline.len(),
+            coastline.iter().map(|l| l.len()).sum::<usize>()
+        );
+
+        // TODO(LL-B): `cliffs.geojson` (slope_threshold_deg) not yet consumed.
         // TODO(LL-C): decode the `biome.u8` layer (semantics ymir.WhittakerBiome@v1),
         //             plus `temperature.i16` / `precipitation.u16`, into game biomes.
 
         Ok(Self {
             manifest,
             height: field,
+            coastline,
         })
     }
+}
+
+/// Parse `coastline.geojson` (a FeatureCollection whose feature is a
+/// MultiLineString) into polylines in cell space. Hand-parsed with serde_json to
+/// avoid a `geojson` dependency. Returns empty if the layer is absent/not present,
+/// unreadable, or malformed (callers fall back to the metric-height threshold).
+fn load_coastline(dir: &Path, manifest: &YmirManifest) -> Vec<Vec<[f32; 2]>> {
+    let layer = manifest.layers.iter().find(|l| l.id == "coastline");
+    let Some(layer) = layer else {
+        return Vec::new();
+    };
+    if !layer.present {
+        return Vec::new();
+    }
+    let file = layer.file.clone().unwrap_or_else(|| "coastline.geojson".to_string());
+    let path = dir.join(&file);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("Ymir: cannot read coastline {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+    let json: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("Ymir: invalid coastline.geojson: {e}");
+            return Vec::new();
+        }
+    };
+
+    // Collect every MultiLineString / LineString geometry, whether the top level
+    // is a FeatureCollection, a single Feature, or a bare geometry.
+    let mut polylines: Vec<Vec<[f32; 2]>> = Vec::new();
+    let mut push_geometry = |geom: &serde_json::Value, out: &mut Vec<Vec<[f32; 2]>>| {
+        let Some(kind) = geom.get("type").and_then(|t| t.as_str()) else {
+            return;
+        };
+        let Some(coords) = geom.get("coordinates") else {
+            return;
+        };
+        let parse_line = |line: &serde_json::Value| -> Vec<[f32; 2]> {
+            line.as_array()
+                .map(|pts| {
+                    pts.iter()
+                        .filter_map(|p| {
+                            let a = p.as_array()?;
+                            Some([a.first()?.as_f64()? as f32, a.get(1)?.as_f64()? as f32])
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        match kind {
+            "MultiLineString" => {
+                if let Some(lines) = coords.as_array() {
+                    for line in lines {
+                        let pl = parse_line(line);
+                        if pl.len() >= 2 {
+                            out.push(pl);
+                        }
+                    }
+                }
+            }
+            "LineString" => {
+                let pl = parse_line(coords);
+                if pl.len() >= 2 {
+                    out.push(pl);
+                }
+            }
+            _ => {}
+        }
+    };
+
+    if let Some(features) = json.get("features").and_then(|f| f.as_array()) {
+        for feat in features {
+            if let Some(geom) = feat.get("geometry") {
+                push_geometry(geom, &mut polylines);
+            }
+        }
+    } else if let Some(geom) = json.get("geometry") {
+        push_geometry(geom, &mut polylines);
+    } else {
+        push_geometry(&json, &mut polylines);
+    }
+
+    polylines
 }

--- a/crates/server/src/world/systems/world_generation.rs
+++ b/crates/server/src/world/systems/world_generation.rs
@@ -84,7 +84,7 @@ pub async fn generate_world_globals(
             global_state.source_biome_flipped_rgba = Some(source_biome_flipped);
             global_state.maps = Some(maps);
             global_state.grid_config = Some(grid_config);
-            global_state.build_effective_binary();
+            global_state.build_effective_binary(true);
             (global_state, terrain_global_data)
         }
         WorldSource::Ymir(ymir) => build_ymir_globals(map_name, &ymir, grid_config, scale),
@@ -191,6 +191,31 @@ pub async fn generate_world_globals(
     // Override world dimensions with real world size (not capped ocean image size)
     ocean_data.world_width = global_state.n_chunk_x as f32 * constants::CHUNK_SIZE.x;
     ocean_data.world_height = global_state.n_chunk_y as f32 * constants::CHUNK_SIZE.y;
+
+    // LL-B (Ymir path): replace the pixel-mask ocean SDF with a signed distance
+    // field derived from the real vector coastline, at the same resolution and
+    // max_distance so the shader beach_start/beach_end thresholds still line up.
+    if !global_state.coastline_cells.is_empty() {
+        if let Some(ref eff) = global_state.effective_binary {
+            let coastal = world::components::coastal_signed_distance_field(
+                &global_state.coastline_cells,
+                global_state.enriched_heightmap_width,
+                global_state.enriched_heightmap_height,
+                ocean_data.width,
+                ocean_data.height,
+                ocean_data.max_distance,
+                eff,
+            );
+            ocean_data.sdf_values = coastal;
+            tracing::info!(
+                "✓ Ocean SDF from Ymir vector coastline ({} polylines → {}x{} SDF, max_distance={})",
+                global_state.coastline_cells.len(),
+                ocean_data.width,
+                ocean_data.height,
+                ocean_data.max_distance,
+            );
+        }
+    }
 
     tracing::info!(
         "🌊 Saving ocean : (texture {}x{}, world_width={}, world_height={})",
@@ -485,8 +510,9 @@ fn build_ymir_globals(
         effective_binary: None,
         effective_binary_smoothed: None,
         water_threshold_norm: sea_level_norm,
+        coastline_cells: ymir.coastline.clone(),
     };
-    global_state.build_effective_binary();
+    global_state.build_effective_binary(false);
 
     tracing::info!(
         "✓ Ymir globals built (enriched pipeline bypassed — coastal-SDF/FBM skipped): {}x{} height, {}x{} chunks, sea_level_norm {:.3}",
@@ -629,9 +655,10 @@ pub async fn load_or_generate_world_globals(
             effective_binary_smoothed: None,
             // Azgaar convention: ocean is exactly 0u16 → threshold 0.0.
             water_threshold_norm: 0.0,
+            coastline_cells: Vec::new(),
         };
 
-        global_state.build_effective_binary();
+        global_state.build_effective_binary(true);
 
         tracing::info!(
             "✓ World globals loaded in {:?} ({}x{} chunks)",


### PR DESCRIPTION
… [LL-B]

Coasts on the Ymir world source now come from Ymir's real vector coastline, and the terrain shader computes true (rise/run) slope from metric height instead of a unitless magic factor. Azgaar path is unchanged (gated on metres_per_cell > 0).

Coastline → ocean SDF:
- ymir_map.rs hand-parses coastline.geojson (serde_json) into cell-space polylines.
- New coastal_sdf.rs computes a signed distance field by point-to-segment distance with a uniform-bin spatial index; sign from the metric-height land mask; same u8 encoding (128 = coast) so beach_start/beach_end are unchanged.
- world_generation.rs overrides the ocean global SDF (the render-critical coast) with this field at the same resolution and max_distance=50. build_effective_binary gains a `smoothed` flag; the Ymir path passes false, dropping the sigma=5 Gaussian mask + re-threshold. Land/sea stays metric height > sea level.

Physical slope shader (terrain_signed_sdf_painterly.wgsl):
- New uniform binding 24 metric_params (metres_per_cell, metres_per_height_unit, sea_level_norm, cliff_threshold_deg), plumbed from TerrainGlobalData through TerrainMaterial and populated at spawn.
- compute_sobel_gradients branches on metres_per_cell > 0 (Ymir): 1-cell Sobel step, rise = dh_norm * 65535 * metres_per_height_unit, run = metres_per_cell, so dzdx/dzdy are true slope. The FBM noise_offset and slope_scale = 3.0 are removed on this path (kept only in the Azgaar branch). Rock and slope-debug thresholds use degrees (atan) around cliff_threshold_deg. Hillshade normal recomputed from the corrected gradients.

Verified: cargo build (server + client) green; Ymir globals generate with the vector ocean SDF (55 polylines, no Gaussian mask); Azgaar path untouched.