### PR TITLE
FEAT: Consume Ymir hydro layers — inland lakes, Lake/Wetland biomes […

### DIFF
--- a/crates/server/src/world/components/biome_mesh_data.rs
+++ b/crates/server/src/world/components/biome_mesh_data.rs
@@ -368,6 +368,11 @@ impl BiomeMeshData {
         let mut hex_ocean: HashMap<hexx::Hex, usize> = HashMap::new();
         let mut hex_lake: HashMap<hexx::Hex, usize> = HashMap::new();
         let mut hex_near_coast: HashSet<hexx::Hex> = HashSet::new();
+        // Ymir path: authoritative per-cell biome ids voted straight from the
+        // resolved grid (keeps Ocean/Lake/Wetland from resolve_biome), bypassing
+        // the ocean/lake/height-override machinery that assumes water == below sea
+        // level (which would demote elevated lakes back to land).
+        let mut hex_grid_biome: HashMap<hexx::Hex, HashMap<u32, usize>> = HashMap::new();
 
         for sy in src_y_min..=src_y_max {
             for sx in src_x_min..=src_x_max {
@@ -427,6 +432,14 @@ impl BiomeMeshData {
 
                         let hex = hex_layout.world_pos_to_hex(Vec2::new(wx, wy));
 
+                        if ymir_biome_ids.is_some() && (id as usize) < 16 {
+                            *hex_grid_biome
+                                .entry(hex)
+                                .or_default()
+                                .entry(id as u32)
+                                .or_insert(0) += 1;
+                        }
+
                         if is_ocean_coast {
                             *hex_ocean.entry(hex).or_insert(0) += 1;
                             hex_near_coast.insert(hex);
@@ -461,6 +474,7 @@ impl BiomeMeshData {
         all_hexes.extend(hex_land.keys());
         all_hexes.extend(hex_ocean.keys());
         all_hexes.extend(hex_lake.keys());
+        all_hexes.extend(hex_grid_biome.keys());
 
         let mut cells: Vec<CellData> = all_hexes
             .into_iter()
@@ -540,6 +554,20 @@ impl BiomeMeshData {
                             _ => biome,
                         }
                     }
+                } else {
+                    biome
+                };
+
+                // Ymir path: the resolved per-cell grid is authoritative (Ocean/
+                // DeepOcean/Lake/Wetland/land already correct) — take its majority
+                // id per hex, overriding the vote + height-based classification
+                // (which would demote elevated lakes back to land).
+                let biome = if ymir_biome_ids.is_some() {
+                    hex_grid_biome
+                        .get(&hex_cell)
+                        .and_then(|m| m.iter().max_by_key(|(_, c)| *c).map(|(id, _)| *id))
+                        .and_then(|id| BiomeTypeEnum::from_id(id as i16))
+                        .unwrap_or(biome)
                 } else {
                     biome
                 };

--- a/crates/server/src/world/components/terrain_mesh_data.rs
+++ b/crates/server/src/world/components/terrain_mesh_data.rs
@@ -195,6 +195,7 @@ impl TerrainMeshData {
             water_threshold_norm: 0.0,
             coastline_cells: Vec::new(),
             ymir_biome_ids: None,
+            water_class_flipped: None,
         };
 
         (global_state, terrain_global_data)

--- a/crates/server/src/world/components/ymir_biome.rs
+++ b/crates/server/src/world/components/ymir_biome.rs
@@ -39,28 +39,33 @@ pub fn whittaker_to_biome(id: u8) -> BiomeTypeEnum {
     }
 }
 
-/// Resolve the final `BiomeTypeEnum` from a Whittaker id plus metric context.
+/// Resolve the final `BiomeTypeEnum` from a Whittaker id plus metric + hydro context.
 ///
-/// **Metric height is the single authority for land vs sea** — it must agree with
-/// the coastline SDF, `effective_binary` and the terrain mesh, which all use
-/// `height > sea_level`. The Whittaker id only chooses the *land* biome type. This
-/// avoids the "water rendered on land" band that appears when Ymir's Whittaker
-/// classifier disagrees with the height coastline (≈18% of id-1 "water" cells sit
-/// above sea level in current maps).
+/// **`water_class` is the authority for land vs water** (Ymir's border flood-fill:
+/// `0` land, `1` ocean = edge-connected sea, `2` inland water = enclosed lake). It
+/// must agree with the `effective_binary`, ocean SDF and lake pipeline, which are
+/// all driven by the same `water_class`. The Whittaker id only chooses the *land*
+/// biome type. When the `water_class` layer is absent the caller derives it from
+/// the calibrated height threshold (`≤ sea_level` → 1, else 0), preserving the
+/// previous height-authority behaviour (no class 2 without the layer).
 ///
-/// Order: (1) `height ≤ sea_level` → `DeepOcean`/`Ocean` by depth; (2) otherwise
-/// land: the Whittaker land biome (Whittaker-water on a land cell falls back to
-/// `Grassland`), then (3) cold land → `Ice`, cold Desert → `ColdDesert`. Lake
-/// (`lake_mask`) and Wetland (`flow_accumulation`+slope) are applied by the caller
-/// only when those layers are present — absent in current maps.
+/// Order:
+/// 1. `water_class == 1` (ocean) → `DeepOcean`/`Ocean` split by bathymetry.
+/// 2. `water_class == 2` (inland water) → **`Wetland`** when the lake is a shallow
+///    flooded depression (#155) else **`Lake`**. This is the one documented place
+///    for the Lake/Wetland predicate (was a no-op until `lake_mask`/`lakes` shipped).
+/// 3. land → the Whittaker land biome (Whittaker-water on a land cell falls back to
+///    `Grassland`), then cold land → `Ice`, cold Desert → `ColdDesert`.
 pub fn resolve_biome(
     whittaker_id: u8,
     temp_c: Option<f32>,
     height_m: f32,
     sea_level_m: f32,
+    water_class: u8,
+    lake_shallow: bool,
 ) -> BiomeTypeEnum {
-    // 1. Sea vs land decided purely by height (bathymetry split for the sea).
-    if height_m <= sea_level_m {
+    // 1. Ocean (edge-connected sea): bathymetry split.
+    if water_class == 1 {
         return if height_m <= sea_level_m + DEEP_OCEAN_DEPTH_M {
             BiomeTypeEnum::DeepOcean
         } else {
@@ -68,8 +73,17 @@ pub fn resolve_biome(
         };
     }
 
-    // 2. Land: use the Whittaker land biome; if Whittaker classed this (above-sea)
-    //    cell as water, fall back to Grassland so land never renders as ocean.
+    // 2. Inland water (enclosed): Wetland if a shallow flooded depression, else Lake.
+    if water_class == 2 {
+        return if lake_shallow {
+            BiomeTypeEnum::Wetland
+        } else {
+            BiomeTypeEnum::Lake
+        };
+    }
+
+    // 3. Land: use the Whittaker land biome; if Whittaker classed this cell as
+    //    water, fall back to Grassland so land never renders as ocean.
     let base = match whittaker_to_biome(whittaker_id) {
         BiomeTypeEnum::Ocean | BiomeTypeEnum::DeepOcean | BiomeTypeEnum::Lake => {
             BiomeTypeEnum::Grassland
@@ -77,7 +91,7 @@ pub fn resolve_biome(
         other => other,
     };
 
-    // 3. Temperature overrides on land.
+    // Temperature overrides on land.
     if let Some(t) = temp_c {
         if t <= ICE_TEMP_C {
             return BiomeTypeEnum::Ice;
@@ -95,36 +109,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn water_splits_by_depth() {
-        assert_eq!(resolve_biome(1, Some(10.0), -500.0, 0.0), BiomeTypeEnum::DeepOcean);
-        assert_eq!(resolve_biome(1, Some(10.0), -10.0, 0.0), BiomeTypeEnum::Ocean);
+    fn ocean_splits_by_depth() {
+        assert_eq!(resolve_biome(1, Some(10.0), -500.0, 0.0, 1, false), BiomeTypeEnum::DeepOcean);
+        assert_eq!(resolve_biome(1, Some(10.0), -10.0, 0.0, 1, false), BiomeTypeEnum::Ocean);
     }
 
     #[test]
     fn temperate_land_maps_directly() {
-        assert_eq!(resolve_biome(4, Some(10.0), 300.0, 0.0), BiomeTypeEnum::Grassland);
-        assert_eq!(resolve_biome(2, Some(-2.0), 3000.0, 0.0), BiomeTypeEnum::Tundra);
-        assert_eq!(resolve_biome(3, Some(2.0), 1500.0, 0.0), BiomeTypeEnum::Taiga);
+        assert_eq!(resolve_biome(4, Some(10.0), 300.0, 0.0, 0, false), BiomeTypeEnum::Grassland);
+        assert_eq!(resolve_biome(2, Some(-2.0), 3000.0, 0.0, 0, false), BiomeTypeEnum::Tundra);
+        assert_eq!(resolve_biome(3, Some(2.0), 1500.0, 0.0, 0, false), BiomeTypeEnum::Taiga);
     }
 
     #[test]
     fn ice_override_on_cold_land() {
-        assert_eq!(resolve_biome(2, Some(-10.0), 3500.0, 0.0), BiomeTypeEnum::Ice);
-        assert_eq!(resolve_biome(4, Some(-8.5), 500.0, 0.0), BiomeTypeEnum::Ice);
+        assert_eq!(resolve_biome(2, Some(-10.0), 3500.0, 0.0, 0, false), BiomeTypeEnum::Ice);
+        assert_eq!(resolve_biome(4, Some(-8.5), 500.0, 0.0, 0, false), BiomeTypeEnum::Ice);
     }
 
     #[test]
     fn cold_desert_override() {
-        assert_eq!(resolve_biome(8, Some(2.0), 400.0, 0.0), BiomeTypeEnum::ColdDesert);
-        assert_eq!(resolve_biome(8, Some(25.0), 400.0, 0.0), BiomeTypeEnum::Desert);
+        assert_eq!(resolve_biome(8, Some(2.0), 400.0, 0.0, 0, false), BiomeTypeEnum::ColdDesert);
+        assert_eq!(resolve_biome(8, Some(25.0), 400.0, 0.0, 0, false), BiomeTypeEnum::Desert);
     }
 
     #[test]
-    fn height_is_the_land_sea_authority() {
-        // Whittaker "water" (id 1) above sea level → land (Grassland fallback),
-        // NOT ocean — this is the fix for the "water rendered on land" band.
-        assert_eq!(resolve_biome(1, Some(10.0), 50.0, 0.0), BiomeTypeEnum::Grassland);
-        // Whittaker "land" (id 5) below sea level → ocean.
-        assert_eq!(resolve_biome(5, Some(10.0), -50.0, 0.0), BiomeTypeEnum::Ocean);
+    fn water_class_is_the_land_sea_authority() {
+        // Whittaker "water" (id 1) on a class-0 cell → land (Grassland fallback),
+        // NOT ocean — regardless of what the Whittaker classifier said.
+        assert_eq!(resolve_biome(1, Some(10.0), 50.0, 0.0, 0, false), BiomeTypeEnum::Grassland);
+        // Whittaker "land" (id 5) on a class-1 cell → ocean.
+        assert_eq!(resolve_biome(5, Some(10.0), -50.0, 0.0, 1, false), BiomeTypeEnum::Ocean);
+    }
+
+    #[test]
+    fn inland_water_is_lake_or_wetland() {
+        // Enclosed inland water (class 2): deep → Lake, shallow depression → Wetland,
+        // whatever the Whittaker id / height say.
+        assert_eq!(resolve_biome(4, Some(10.0), -30.0, 0.0, 2, false), BiomeTypeEnum::Lake);
+        assert_eq!(resolve_biome(4, Some(10.0), -2.0, 0.0, 2, true), BiomeTypeEnum::Wetland);
     }
 }

--- a/crates/server/src/world/resources/world_global_state.rs
+++ b/crates/server/src/world/resources/world_global_state.rs
@@ -72,6 +72,15 @@ pub struct WorldGlobalState {
     /// `None` on the Azgaar path or Ymir maps without a `biome.u8` layer, in which
     /// case per-chunk biome falls back to `find_closest_biome`.
     pub ymir_biome_ids: Option<Vec<u8>>,
+
+    /// Ymir per-cell **effective** inland-water class (0 land / 1 ocean =
+    /// edge-connected sea / 2 inland water = a `lake_mask` drainage lake or an
+    /// enclosed below-sea pocket), Y-flipped to display orientation (grid =
+    /// heightmap dims). On the Ymir path this is the authority for the land/sea
+    /// split and the lake source: `effective_binary` marks only class 1 as ocean
+    /// water, and the lake SDF is built from class-2 cells. `None` on the Azgaar
+    /// path or when both hydro layers are absent (then the height threshold is used).
+    pub water_class_flipped: Option<Vec<u8>>,
 }
 
 impl WorldGlobalState {

--- a/crates/server/src/world/resources/ymir_map.rs
+++ b/crates/server/src/world/resources/ymir_map.rs
@@ -84,6 +84,60 @@ pub struct Layer {
 }
 
 // ---------------------------------------------------------------------------
+// lakes.json schema (Ymir C1Lake) + the mirror we keep
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawLake {
+    base: RawLakeBase,
+    #[serde(default)]
+    level_m: f32,
+    #[serde(default)]
+    depth_m: f32,
+    #[serde(default)]
+    area_km2: f32,
+    #[serde(default)]
+    lake_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawLakeBase {
+    id: u32,
+    #[serde(default)]
+    outlet: Option<[i64; 2]>,
+    #[serde(default)]
+    shallow: bool,
+}
+
+/// Endorheic (closed basin, no outlet) vs Exorheic (drains to the sea). Used
+/// later for salt/closed-basin visuals; `Unknown` if the field is missing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LakeType {
+    Exorheic,
+    Endorheic,
+    Unknown,
+}
+
+/// One inland lake, mirrored from `lakes.json`. `lake_mask` cells carry this
+/// lake's [`id`](LakeInfo::id). Coordinates (outlet) are erosion-grid cells.
+#[derive(Debug, Clone)]
+pub struct LakeInfo {
+    /// 1-based lake id; matches the per-cell value in `lake_mask` (0 = no lake).
+    pub id: u32,
+    /// Water-surface elevation, metres.
+    pub level_m: f32,
+    /// Maximum depth, metres.
+    pub depth_m: f32,
+    /// Surface area, km².
+    pub area_km2: f32,
+    /// Flooded shallow depression (#155) → Wetland; deep lake otherwise.
+    pub shallow: bool,
+    pub lake_type: LakeType,
+    /// Outlet cell (erosion grid), if any.
+    pub outlet: Option<[i64; 2]>,
+}
+
+// ---------------------------------------------------------------------------
 // Decoded height layer
 // ---------------------------------------------------------------------------
 
@@ -201,6 +255,20 @@ pub struct YmirMap {
     pub biome: Vec<u8>,
     /// `temperature.i16` — °C × 100 per cell, row-major, y=0 = south. Empty if absent.
     pub temperature: Vec<i16>,
+    /// `water_class.u8` — per cell: 0 = land, 1 = ocean (edge-connected sea),
+    /// 2 = inland water (enclosed below-sea / lake). Row-major, y=0 = south.
+    /// Empty if absent — callers then fall back to the height/coastline threshold.
+    pub water_class: Vec<u8>,
+    /// `lake_mask.u32` — per-cell lake id (0 = no lake), matching [`LakeInfo::id`].
+    /// Row-major, y=0 = south. Empty if absent.
+    pub lake_mask: Vec<u32>,
+    /// `flow_accumulation.f32` — per-cell upstream flow. Row-major, y=0 = south.
+    /// Empty if absent. (Loaded for future river/wetland use.)
+    pub flow_accumulation: Vec<f32>,
+    /// Inland lakes mirrored from `lakes.json` (empty if absent).
+    pub lakes: Vec<LakeInfo>,
+    /// `lake id → index into lakes` for O(1) per-cell lookup.
+    lakes_by_id: std::collections::HashMap<u32, usize>,
 }
 
 impl YmirMap {
@@ -212,6 +280,34 @@ impl YmirMap {
         }
         let idx = (y as usize) * (self.height.width as usize) + (x as usize);
         self.temperature.get(idx).map(|&t| t as f32 / 100.0)
+    }
+
+    /// Water class at cell `(x, y)` (0 land / 1 ocean / 2 inland), or `None` if
+    /// the `water_class` layer is absent.
+    #[inline]
+    pub fn water_class_at(&self, x: u32, y: u32) -> Option<u8> {
+        if self.water_class.is_empty() {
+            return None;
+        }
+        let idx = (y as usize) * (self.height.width as usize) + (x as usize);
+        self.water_class.get(idx).copied()
+    }
+
+    /// Lake id at cell `(x, y)` (0 = no lake), or `None` if the `lake_mask` layer
+    /// is absent.
+    #[inline]
+    pub fn lake_id_at(&self, x: u32, y: u32) -> Option<u32> {
+        if self.lake_mask.is_empty() {
+            return None;
+        }
+        let idx = (y as usize) * (self.height.width as usize) + (x as usize);
+        self.lake_mask.get(idx).copied()
+    }
+
+    /// Lake metadata for a given `lake_mask` id, or `None`.
+    #[inline]
+    pub fn lake(&self, id: u32) -> Option<&LakeInfo> {
+        self.lakes_by_id.get(&id).map(|&i| &self.lakes[i])
     }
 }
 
@@ -356,10 +452,22 @@ impl YmirMap {
             temperature.len()
         );
 
+        // ── hydro layers (LL-D): water_class, lake_mask, flow_accumulation, lakes ──
+        let water_class = load_water_class(&dir, &manifest, width, height);
+        let lake_mask = load_lake_mask(&dir, &manifest, width, height);
+        let flow_accumulation = load_flow_accumulation(&dir, &manifest, width, height);
+        let lakes = load_lakes(&dir, &manifest);
+        let lakes_by_id = lakes.iter().enumerate().map(|(i, l)| (l.id, i)).collect();
+        tracing::info!(
+            "✓ Ymir hydro: water_class {} cells, lake_mask {} cells, flow_accumulation {} cells, {} lakes",
+            water_class.len(),
+            lake_mask.len(),
+            flow_accumulation.len(),
+            lakes.len(),
+        );
+
         // Cliffs (cliffs.geojson) are consumed client-side by the debug overlay
         // (LL-C), read directly from the .ymir asset via the shared GeoJSON reader.
-        // TODO(LL-C+): flow_accumulation / lake_mask (absent in current maps) for
-        //             Wetland / Lake biome rules.
 
         Ok(Self {
             manifest,
@@ -367,6 +475,11 @@ impl YmirMap {
             coastline,
             biome,
             temperature,
+            water_class,
+            lake_mask,
+            flow_accumulation,
+            lakes,
+            lakes_by_id,
         })
     }
 }
@@ -458,5 +571,153 @@ fn load_temperature_i16(dir: &Path, manifest: &YmirManifest, w: u32, h: u32) -> 
     bytes
         .chunks_exact(2)
         .map(|c| i16::from_le_bytes([c[0], c[1]]))
+        .collect()
+}
+
+/// Load the `water_class.u8` layer (0 land / 1 ocean / 2 inland, row-major,
+/// y=0 south). Empty if absent/not present or size mismatch.
+fn load_water_class(dir: &Path, manifest: &YmirManifest, w: u32, h: u32) -> Vec<u8> {
+    let Some(layer) = manifest.layers.iter().find(|l| l.id == "water_class") else {
+        return Vec::new();
+    };
+    if !layer.present {
+        return Vec::new();
+    }
+    let file = layer.file.clone().unwrap_or_else(|| "water_class.u8".to_string());
+    let path = dir.join(&file);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("Ymir: cannot read water_class {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+    let expected = (w as usize) * (h as usize);
+    if bytes.len() != expected {
+        tracing::warn!(
+            "Ymir: water_class.u8 is {} bytes, expected {} ({}x{}) — ignoring",
+            bytes.len(),
+            expected,
+            w,
+            h
+        );
+        return Vec::new();
+    }
+    bytes
+}
+
+/// Load the `lake_mask.u32` layer (per-cell lake id, LE, row-major, y=0 south).
+/// Empty if absent/not present or size mismatch.
+fn load_lake_mask(dir: &Path, manifest: &YmirManifest, w: u32, h: u32) -> Vec<u32> {
+    let Some(layer) = manifest.layers.iter().find(|l| l.id == "lake_mask") else {
+        return Vec::new();
+    };
+    if !layer.present {
+        return Vec::new();
+    }
+    let file = layer.file.clone().unwrap_or_else(|| "lake_mask.u32".to_string());
+    let path = dir.join(&file);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("Ymir: cannot read lake_mask {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+    let expected = (w as usize) * (h as usize) * 4;
+    if bytes.len() != expected {
+        tracing::warn!(
+            "Ymir: lake_mask.u32 is {} bytes, expected {} ({}x{}x4) — ignoring",
+            bytes.len(),
+            expected,
+            w,
+            h
+        );
+        return Vec::new();
+    }
+    bytes
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// Load the `flow_accumulation.f32` layer (LE, row-major, y=0 south).
+/// Empty if absent/not present or size mismatch.
+fn load_flow_accumulation(dir: &Path, manifest: &YmirManifest, w: u32, h: u32) -> Vec<f32> {
+    let Some(layer) = manifest.layers.iter().find(|l| l.id == "flow_accumulation") else {
+        return Vec::new();
+    };
+    if !layer.present {
+        return Vec::new();
+    }
+    let file = layer
+        .file
+        .clone()
+        .unwrap_or_else(|| "flow_accumulation.f32".to_string());
+    let path = dir.join(&file);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("Ymir: cannot read flow_accumulation {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+    let expected = (w as usize) * (h as usize) * 4;
+    if bytes.len() != expected {
+        tracing::warn!(
+            "Ymir: flow_accumulation.f32 is {} bytes, expected {} ({}x{}x4) — ignoring",
+            bytes.len(),
+            expected,
+            w,
+            h
+        );
+        return Vec::new();
+    }
+    bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// Parse `lakes.json` (Ymir C1Lake array) into a [`LakeInfo`] mirror. Empty if
+/// absent/not present or unparseable.
+fn load_lakes(dir: &Path, manifest: &YmirManifest) -> Vec<LakeInfo> {
+    let Some(layer) = manifest.layers.iter().find(|l| l.id == "lakes") else {
+        return Vec::new();
+    };
+    if !layer.present {
+        return Vec::new();
+    }
+    let file = layer.file.clone().unwrap_or_else(|| "lakes.json".to_string());
+    let path = dir.join(&file);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("Ymir: cannot read lakes {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+    let parsed: Vec<RawLake> = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("Ymir: invalid lakes.json: {e}");
+            return Vec::new();
+        }
+    };
+    parsed
+        .into_iter()
+        .map(|r| LakeInfo {
+            id: r.base.id,
+            level_m: r.level_m,
+            depth_m: r.depth_m,
+            area_km2: r.area_km2,
+            shallow: r.base.shallow,
+            lake_type: match r.lake_type.as_deref() {
+                Some("Exorheic") => LakeType::Exorheic,
+                Some("Endorheic") => LakeType::Endorheic,
+                _ => LakeType::Unknown,
+            },
+            outlet: r.base.outlet,
+        })
         .collect()
 }

--- a/crates/server/src/world/systems/world_generation.rs
+++ b/crates/server/src/world/systems/world_generation.rs
@@ -261,20 +261,30 @@ pub async fn generate_world_globals(
     // 4. Derive mask from SDF (no separate mask computation)
     let lake_eff_src = global_state.effective_binary_smoothed.as_ref()
         .or(global_state.effective_binary.as_ref());
+    // Ymir: inland water (effective class 2 = lake_mask or enclosed below-sea) is
+    // the authoritative lake source, independent of effective_binary (which marks
+    // class 2 as land so the ocean never covers it). Its grid == enriched dims ==
+    // effective_binary dims, same display orientation.
+    let wc_flipped = global_state.water_class_flipped.as_deref();
     let lake_binary = if let Some(eff) = lake_eff_src {
         let bw = eff.width();
         let bh = eff.height();
 
-        // Build lake binary: water pixels that are also in lake_src
+        // Build lake binary (SDF convention: lake=0 water, land=255).
         let eff_lake = ImageBuffer::<Luma<u8>, Vec<u8>>::from_fn(bw, bh, |x, y| {
-            let is_water = eff.get_pixel(x, y)[0] == 0;
-            let wx = x as f32 / bw as f32;
-            let wy = y as f32 / bh as f32;
-            let lx = (wx * lake_w as f32).min(lake_w as f32 - 1.0) as u32;
-            let ly = ((1.0 - wy) * (lake_h as f32 - 1.0)) as u32;
-            let is_lake_src = lake_src.get_pixel(lx, ly)[0] > 128;
-            // Inverted for SDF convention: lake=0 (water), land=255
-            Luma([if is_water && is_lake_src { 0u8 } else { 255u8 }])
+            let is_lake = if let Some(wc) = wc_flipped {
+                let idx = (y as usize) * (bw as usize) + (x as usize);
+                wc.get(idx).copied() == Some(2)
+            } else {
+                // Azgaar: water pixels that are also in the lake source map.
+                let is_water = eff.get_pixel(x, y)[0] == 0;
+                let wx = x as f32 / bw as f32;
+                let wy = y as f32 / bh as f32;
+                let lx = (wx * lake_w as f32).min(lake_w as f32 - 1.0) as u32;
+                let ly = ((1.0 - wy) * (lake_h as f32 - 1.0)) as u32;
+                is_water && lake_src.get_pixel(lx, ly)[0] > 128
+            };
+            Luma([if is_lake { 0u8 } else { 255u8 }])
         });
 
         // Resize to capped resolution (same as ocean binary cap)
@@ -426,6 +436,17 @@ fn build_ymir_globals(
     // place of find_closest_biome on the Ymir path. Empty (→ None) if no biome.u8.
     let mut biome_ids: Vec<u8> = if has_biome { vec![0u8; w * h] } else { Vec::new() };
 
+    // LL-D: derive a per-cell inland-water class (0 land / 1 ocean / 2 inland
+    // water) from Ymir's water_class (ocean vs enclosed-below-sea) folded with
+    // lake_mask (real drainage lakes, which sit on land at elevation so are
+    // water_class 0). A Y-flipped copy feeds the effective_binary and lake source
+    // built below. `1` (ocean) is the only non-terrain class.
+    let has_water_class = !ymir.water_class.is_empty();
+    let has_lake_mask = !ymir.lake_mask.is_empty();
+    let has_inland = has_water_class || has_lake_mask;
+    let mut water_class_flipped: Vec<u8> =
+        if has_inland { vec![0u8; w * h] } else { Vec::new() };
+
     for y in 0..h {
         let src_row = (h - 1 - y) * w; // vertical flip; raw Ymir row = h-1-y
         let raw_y = (h - 1 - y) as u32;
@@ -433,7 +454,32 @@ fn build_ymir_globals(
         for x in 0..w {
             let v = hf.data[src_row + x];
             let height_m = hf.metres_of_u16(v);
-            let is_land = height_m > sea_level_m;
+
+            // Land/sea authority: water_class (ocean vs enclosed-below-sea) when
+            // present, else the calibrated height threshold (0/1). A lake_mask cell
+            // is inland water (class 2) even above sea level. Ocean (class 1) wins
+            // and is the only non-terrain class — inland water keeps a terrain mesh
+            // (lake bank) and is drawn by the lake pipeline, so it counts as "land"
+            // for the ocean binary and the chunk source binary.
+            let lake_id = ymir.lake_id_at(x as u32, raw_y).unwrap_or(0);
+            let raw_class = if has_water_class {
+                ymir.water_class[src_row + x]
+            } else if height_m <= sea_level_m {
+                1
+            } else {
+                0
+            };
+            let class = if raw_class == 1 {
+                1
+            } else if lake_id != 0 || raw_class == 2 {
+                2
+            } else {
+                0
+            };
+            let is_land = class != 1;
+            if has_inland {
+                water_class_flipped[dst_row + x] = class;
+            }
 
             let hb = v.to_le_bytes();
             let ho = (dst_row + x) * 2;
@@ -443,7 +489,12 @@ fn build_ymir_globals(
             let biome = if has_biome {
                 let whittaker_id = ymir.biome[src_row + x];
                 let temp_c = ymir.temperature_c_at(x as u32, raw_y);
-                resolve_biome(whittaker_id, temp_c, height_m, sea_level_m)
+                // Wetland vs Lake for inland water from the lake's shallow flag.
+                let lake_shallow =
+                    lake_id != 0 && ymir.lake(lake_id).map(|l| l.shallow).unwrap_or(false);
+                resolve_biome(whittaker_id, temp_c, height_m, sea_level_m, class, lake_shallow)
+            } else if class == 2 {
+                BiomeTypeEnum::Lake
             } else if is_land {
                 BiomeTypeEnum::Grassland
             } else {
@@ -492,8 +543,17 @@ fn build_ymir_globals(
         tracing::info!("Ymir biome.u8 absent — using height-only placeholder biome");
     }
 
-    // No lake layer in LL-A → empty lake mask.
-    let source_lake_flipped = image::ImageBuffer::<Luma<u8>, Vec<u8>>::new(hf.width, hf.height);
+    // Per-chunk lake source (display orientation): inland water (effective class
+    // 2 = lake_mask or enclosed below-sea). Feeds sample_biome_for_chunk's lake
+    // detection + Lakebank shore-type. Empty when no hydro layer is present.
+    let source_lake_flipped = if has_inland {
+        image::ImageBuffer::<Luma<u8>, Vec<u8>>::from_fn(hf.width, hf.height, |x, y| {
+            let c = water_class_flipped[(y * hf.width + x) as usize];
+            Luma([if c == 2 { 255 } else { 0 }])
+        })
+    } else {
+        image::ImageBuffer::<Luma<u8>, Vec<u8>>::new(hf.width, hf.height)
+    };
 
     // Chunk grid — same convention as Azgaar (source px × scale ÷ CHUNK_SIZE).
     // NOTE: world units are not yet calibrated to metres; metres_per_cell is
@@ -552,8 +612,26 @@ fn build_ymir_globals(
         water_threshold_norm: sea_level_norm,
         coastline_cells: ymir.coastline.clone(),
         ymir_biome_ids: if has_biome { Some(biome_ids) } else { None },
+        water_class_flipped: if has_inland {
+            Some(water_class_flipped)
+        } else {
+            None
+        },
     };
-    global_state.build_effective_binary(false);
+
+    if has_inland {
+        // The inland-water class is the authority: the effective binary marks only
+        // ocean (class 1) as water, so the ocean SDF/shader never covers inland
+        // lakes (class 2) — that removes the inland "blue spots".
+        // `source_binary_flipped` was built with exactly this rule (land = class
+        // != 1), so reuse it.
+        global_state.effective_binary = Some(global_state.source_binary_flipped.clone());
+        tracing::info!(
+            "✓ Ymir effective_binary from water_class + lake_mask (class 1 = ocean water)"
+        );
+    } else {
+        global_state.build_effective_binary(false);
+    }
 
     tracing::info!(
         "✓ Ymir globals built (enriched pipeline bypassed — coastal-SDF/FBM skipped): {}x{} height, {}x{} chunks, sea_level_norm {:.3}",
@@ -580,8 +658,21 @@ fn build_ymir_worldmaps(ymir: &YmirMap, n_chunk_x: i32, n_chunk_y: i32) -> World
     let binary_map = image::ImageBuffer::<Luma<u8>, Vec<u8>>::from_fn(w, h, |x, y| {
         Luma([if hf.metres_at(x, y) > sea_level_m { 255 } else { 0 }])
     });
-    // Empty lake mask (Ymir lake layer not present in LL-A).
-    let lake_map = image::ImageBuffer::<Luma<u8>, Vec<u8>>::new(w, h);
+    // Lake mask (raw orientation): inland water cells — a real drainage lake
+    // (lake_mask != 0) or an enclosed below-sea pocket (water_class == 2). Empty if
+    // neither layer is present. 255 = lake cell (Azgaar lake_map convention).
+    let has_lm = !ymir.lake_mask.is_empty();
+    let has_wc = !ymir.water_class.is_empty();
+    let lake_map = if !has_lm && !has_wc {
+        image::ImageBuffer::<Luma<u8>, Vec<u8>>::new(w, h)
+    } else {
+        image::ImageBuffer::<Luma<u8>, Vec<u8>>::from_fn(w, h, |x, y| {
+            let i = (y * w + x) as usize;
+            let in_lake = has_lm && ymir.lake_mask[i] != 0;
+            let enclosed = has_wc && ymir.water_class[i] == 2;
+            Luma([if in_lake || enclosed { 255 } else { 0 }])
+        })
+    };
     // Placeholder biome image (Grassland land / Ocean water) for the legacy batch path.
     let biome_rgba = image::ImageBuffer::<Rgba<u8>, Vec<u8>>::from_fn(w, h, |x, y| {
         if hf.metres_at(x, y) > sea_level_m {
@@ -698,6 +789,7 @@ pub async fn load_or_generate_world_globals(
             water_threshold_norm: 0.0,
             coastline_cells: Vec::new(),
             ymir_biome_ids: None,
+            water_class_flipped: None,
         };
 
         global_state.build_effective_binary(true);

--- a/docs/ymir-future-work.md
+++ b/docs/ymir-future-work.md
@@ -37,22 +37,29 @@ distance-based (correct) instead of a blur (approximate).
 
 ---
 
-## 2. Inland below-sea cells — coastline flood-fill / lakes
+## 2. Inland water — DONE (LL-D), except per-lake water level
 
-**Context.** Sea level is calibrated to the vector coastline (norm ≈ 0.574; commit
-`bc9633d`), so land/sea is consistent across mesh, ocean SDF and biome. But cells
-that are **below sea level yet enclosed by land** (inland depressions) are classed
-as Ocean and rendered blue, even though the ocean shader (which follows the
-coastline) doesn't reach them — the residual inland "blue spots".
+**Resolved.** Ymir now exports `water_class.u8` (0 land / 1 ocean edge-connected /
+2 inland enclosed), `lake_mask.u32` (per-cell lake id), `flow_accumulation.f32` and
+`lakes.json` (per-lake `level_m`, `shallow`, `lake_type`). The consumer (LL-D) reads
+them (`ymir_map.rs`) and derives an **effective inland-water class** (water_class
+folded with lake_mask) that drives: the `effective_binary` (only class 1 is ocean →
+no more blue spots), the lake SDF source (class 2 → existing lake shader), the
+per-cell biome (`resolve_biome`: class 2 → Lake, or Wetland when the lake is
+shallow — the previously-no-op rules), and the per-chunk lake detection + Lakebank
+shore-type. Azgaar path untouched.
 
-**What's needed.** Distinguish ocean-connected water from enclosed water:
-- a **flood-fill from the map border**: below-sea cells reachable from the edge =
-  Ocean; enclosed below-sea = Lake (then the lake shader / terrain lake-bank
-  handles them). This could run server-side, but is cleaner as a Ymir layer;
-- ideally Ymir ships the already-present-but-empty **`lake_mask`** layer
-  (`present: false` in current maps), which removes the guesswork entirely and
-  also unlocks the Lake/Wetland biome rules that are currently no-ops
-  (`crates/server/src/world/components/ymir_biome.rs`).
+**Ymir-side follow-up:** the hydro-export must also **update `manifest.json`** — set
+`present: true` for the hydro layers and add a `water_class` raster layer entry;
+otherwise the consumer stays inert (it honours the present flags).
+
+**Remaining (Phase 2, cross-cutting):** the lake pipeline renders a **single flat
+water layer** — no per-lake elevation. `lakes.json` `level_m` (and `lake_type`
+Endorheic for salt/closed-basin visuals) are loaded but unused. True per-lake
+surface elevation / elevation-accurate shorelines needs a change across the shared
+`LakeData` type, server generation, the client cache, and both the lake and terrain
+shaders (a per-cell lake-level texture). Deferred until the top-down flat render is
+insufficient. Also unconsumed: `rivers.json` (river rendering / navigability).
 
 ---
 


### PR DESCRIPTION
…LL-D]

Ymir now exports water_class.u8 (0 land / 1 ocean edge-connected / 2 inland enclosed), lake_mask.u32 (per-cell lake id), flow_accumulation.f32 and lakes.json (per-lake level_m, shallow, lake_type). Consume them on the .ymir path; Azgaar path untouched.

- ymir_map.rs: load water_class / lake_mask / flow_accumulation and parse lakes.json into a LakeInfo mirror, following the present-flag optional-layer pattern; add water_class_at / lake_id_at / lake(id) accessors.
- world_generation.rs: derive a per-cell effective inland-water class (water_class folded with lake_mask, since drainage lakes sit on land at elevation so are water_class 0). effective_binary marks only class 1 as ocean water, so the ocean SDF never covers inland lakes (removes the blue spots); the lake SDF source is built from class-2 cells; source_lake_flipped is populated so per-chunk lake detection + Lakebank shore-type work. New WorldGlobalState.water_class_flipped.
- ymir_biome.rs: water_class is the land/water authority in resolve_biome; class 2 resolves to Wetland (shallow flooded depression) else Lake — the previously no-op rules. Tests updated (+ inland-water case).
- biome_mesh_data.rs: on the Ymir path use the authoritative resolved biome grid directly per hex, bypassing the Azgaar vote + enriched-height override (which assumes water == below sea level and demoted elevated lakes back to land).

Verified on seed42_2048: biome Lake=6393 / Wetland=288 (161 lakes), inland lakes render via the existing lake pipeline, blue spots gone, Lakebank shores present.

Note: the Ymir export must also update manifest.json (present flags + a water_class layer) or the consumer stays inert. Per-lake level_m rendering deferred (Phase 2).